### PR TITLE
feat: connect ridership page to database API

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,10 +1,14 @@
-import "dotenv/config";
+import dotenv from "dotenv";
+
+// Load .env.local first (Next.js convention), then .env
+dotenv.config({ path: ".env.local" });
+dotenv.config();
 
 import { defineConfig } from "drizzle-kit";
 
 export default defineConfig({
   out: "./drizzle",
-  schema: "./src/db/schema.ts",
+  schema: "./src/db/schema/index.ts",
   dialect: "postgresql",
   dbCredentials: {
     url: process.env.DATABASE_URL,

--- a/drizzle/0001_add_ridership_and_charter_tables.sql
+++ b/drizzle/0001_add_ridership_and_charter_tables.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "ridership_metrics" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"reporting_month" date NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,320 @@
+{
+  "id": "e96bcb05-16fe-4183-b803-7354f453d0fd",
+  "prevId": "28151922-345e-40dd-a579-9358c016916d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.charter_events": {
+      "name": "charter_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reporting_month": {
+          "name": "reporting_month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passenger_count": {
+          "name": "passenger_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vehicle_hours": {
+          "name": "vehicle_hours",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vehicle_miles": {
+          "name": "vehicle_miles",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driver_assignments": {
+          "name": "driver_assignments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenue_total": {
+          "name": "revenue_total",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_total": {
+          "name": "service_total",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ridership_metrics": {
+      "name": "ridership_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reporting_month": {
+          "name": "reporting_month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1755048222201,
       "tag": "0000_dear_phalanx",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1771903536815,
+      "tag": "0001_add_ridership_and_charter_tables",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "lint:fix": "next lint --fix",
-    "check": "concurrently --kill-others-on-fail 'pnpm lint' 'tsc --noEmit'"
+    "check": "concurrently --kill-others-on-fail 'next lint' 'tsc --noEmit'"
   },
   "dependencies": {
     "@auth/drizzle-adapter": "^1.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,13 +37,16 @@ importers:
         version: 8.10.0(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@mui/system@7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@mui/x-date-pickers':
         specifier: ^8.16.0
-        version: 8.16.0(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@mui/system@7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(date-fns@4.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 8.16.0(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@mui/system@7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(date-fns@4.1.0)(dayjs@1.11.19)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@neondatabase/serverless':
         specifier: ^1.0.1
         version: 1.0.1
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      dayjs:
+        specifier: ^1.11.19
+        version: 1.11.19
       dotenv:
         specifier: ^17.2.1
         version: 17.2.1
@@ -63,7 +66,7 @@ importers:
         specifier: ^10.19.0
         version: 10.20.0
       react:
-        specifier: 19.1.0
+        specifier: ^19.1.0
         version: 19.1.0
       react-dom:
         specifier: 19.1.0
@@ -661,78 +664,92 @@ packages:
     resolution: {integrity: sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.0':
     resolution: {integrity: sha512-mWd2uWvDtL/nvIzThLq3fr2nnGfyr/XMXlq8ZJ9WMR6PXijHlC3ksp0IpuhK6bougvQrchUAfzRLnbsen0Cqvw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.0':
     resolution: {integrity: sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.0':
     resolution: {integrity: sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.0':
     resolution: {integrity: sha512-ZW3FPWIc7K1sH9E3nxIGB3y3dZkpJlMnkk7z5tu1nSkBoCgw2nSRTFHI5pB/3CQaJM0pdzMF3paf9ckKMSE9Tg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.0':
     resolution: {integrity: sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.0':
     resolution: {integrity: sha512-SRYOLR7CXPgNze8akZwjoGBoN1ThNZoqpOgfnOxmWsklTGVfJiGJoC/Lod7aNMGA1jSsKWM1+HRX43OP6p9+6Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.3':
     resolution: {integrity: sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.3':
     resolution: {integrity: sha512-oBK9l+h6KBN0i3dC8rYntLiVfW8D8wH+NPNT3O/WBHeW0OQWCjfWksLUaPidsrDKpJgXp3G3/hkmhptAW0I3+A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.3':
     resolution: {integrity: sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.3':
     resolution: {integrity: sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.3':
     resolution: {integrity: sha512-8kYso8d806ypnSq3/Ly0QEw90V5ZoHh10yH0HnrzOCr6DKAPI6QVHvwleqMkVQ0m+fc7EH8ah0BB0QPuWY6zJQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.3':
     resolution: {integrity: sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.3':
     resolution: {integrity: sha512-gCWUn9547K5bwvOn9l5XGAEjVTTRji4aPTqLzGXHvIr6bIDZKNTA34seMPgM0WmSf+RYBH411VavCejp3PkOeQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.3':
     resolution: {integrity: sha512-+CyRcpagHMGteySaWos8IbnXcHgfDn7pO2fiC2slJxvNq9gDipYBN42/RagzctVRKgxATmfqOSulgZv5e1RdMg==}
@@ -1002,24 +1019,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.4.6':
     resolution: {integrity: sha512-XBbuQddtY1p5FGPc2naMO0kqs4YYtLYK/8aPausI5lyOjr4J77KTG9mtlU4P3NwkLI1+OjsPzKVvSJdMs3cFaw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.4.6':
     resolution: {integrity: sha512-+WTeK7Qdw82ez3U9JgD+igBAP75gqZ1vbK6R8PlEEuY0OIe5FuYXA4aTjL811kWPf7hNeslD4hHK2WoM9W0IgA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.4.6':
     resolution: {integrity: sha512-XP824mCbgQsK20jlXKrUpZoh/iO3vUWhMpxCz8oYeagoiZ4V0TQiKy0ASji1KK6IAe3DYGfj5RfKP6+L2020OQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.4.6':
     resolution: {integrity: sha512-FxrsenhUz0LbgRkNWx6FRRJIPe/MI1JRA4W4EPd5leXO00AZ6YU8v5vfx4MDXTvN77lM/EqsE3+6d2CIeF5NYg==}
@@ -1088,41 +1109,49 @@ packages:
     resolution: {integrity: sha512-SjwhNynjSG2yMdyA0f7wz7Yvo3ppejO+ET7n2oiI7ApCXrwxMzeRWjBzQt+oVWr2HzVOfaEcDS9rMtnR83ulig==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.6.1':
     resolution: {integrity: sha512-f4EMidK6rosInBzPMnJ0Ri4RttFCvvLNUNDFUBtELW/MFkBwPTDlvbsmW0u0Mk/ruBQ2WmRfOZ6tT62kWMcX2Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.6.1':
     resolution: {integrity: sha512-1umENVKeUsrWnf5IlF/6SM7DCv8G6CoKI2LnYR6qhZuLYDPS4PBZ0Jow3UDV9Rtbv5KRPcA3/uXjI88ntWIcOQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.6.1':
     resolution: {integrity: sha512-Hjyp1FRdJhsEpIxsZq5VcDuFc8abC0Bgy8DWEa31trCKoTz7JqA7x3E2dkFbrAKsEFmZZ0NvuG5Ip3oIRARhow==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.6.1':
     resolution: {integrity: sha512-ODJOJng6f3QxpAXhLel3kyWs8rPsJeo9XIZHzA7p//e+5kLMDU7bTVk4eZnUHuxsqsB8MEvPCicJkKCEuur5Ag==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.6.1':
     resolution: {integrity: sha512-hCzRiLhqe1ZOpHTsTGKp7gnMJRORlbCthawBueer2u22RVAka74pV/+4pP1tqM07mSlQn7VATuWaDw9gCl+cVg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.6.1':
     resolution: {integrity: sha512-JansPD8ftOzMYIC3NfXJ68tt63LEcIAx44Blx6BAd7eY880KX7A0KN3hluCrelCz5aQkPaD95g8HBiJmKaEi2w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.6.1':
     resolution: {integrity: sha512-R78ES1rd4z2x5NrFPtSWb/ViR1B8wdl+QN2X8DdtoYcqZE/4tvWtn9ZTCXMEzUp23tchJ2wUB+p6hXoonkyLpA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-wasm32-wasi@11.6.1':
     resolution: {integrity: sha512-qAR3tYIf3afkij/XYunZtlz3OH2Y4ni10etmCFIJB5VRGsqJyI6Hl+2dXHHGJNwbwjXjSEH/KWJBpVroF3TxBw==}
@@ -1348,41 +1377,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1669,6 +1706,9 @@ packages:
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
+  dayjs@1.11.19:
+    resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -3827,7 +3867,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-date-pickers@8.16.0(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@mui/system@7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(date-fns@4.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@mui/x-date-pickers@8.16.0(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@mui/system@7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(date-fns@4.1.0)(dayjs@1.11.19)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@mui/material': 7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -3844,6 +3884,7 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@19.1.9)(react@19.1.0)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0)
       date-fns: 4.1.0
+      dayjs: 1.11.19
     transitivePeerDependencies:
       - '@types/react'
 
@@ -4543,6 +4584,8 @@ snapshots:
       is-data-view: 1.0.2
 
   date-fns@4.1.0: {}
+
+  dayjs@1.11.19: {}
 
   debug@3.2.7:
     dependencies:

--- a/src/app/api/charters/route.ts
+++ b/src/app/api/charters/route.ts
@@ -1,7 +1,10 @@
 // src/app/api/charters/route.ts
 import { NextRequest, NextResponse } from "next/server";
+
 import db from "@/db";
 import { charterEvents } from "@/db/schema";
+
+type NewCharterEvent = typeof charterEvents.$inferInsert;
 
 type CharterEventPayload = {
   reportingMonth: string | null; // ISO string from client
@@ -15,7 +18,7 @@ type CharterEventPayload = {
   serviceTotal: number | null;
 };
 
-export async function POST(req: NextRequest) {
+export async function POST(req: NextRequest): Promise<NextResponse> {
   try {
     const body = (await req.json()) as CharterEventPayload;
 
@@ -39,20 +42,23 @@ export async function POST(req: NextRequest) {
     }
 
     await db.insert(charterEvents).values({
-      reportingMonth: new Date(reportingMonth),
+      // Drizzle `date` column expects a string like "YYYY-MM-DD"
+      reportingMonth: new Date(reportingMonth).toISOString().slice(0, 10),
       eventType,
-      eventDate: eventDate ? new Date(eventDate) : null,
+      eventDate: eventDate
+        ? new Date(eventDate).toISOString().slice(0, 10)
+        : null,
       passengerCount,
       vehicleHours,
       vehicleMiles,
       driverAssignments,
       revenueTotal,
       serviceTotal,
-    });
+    } as NewCharterEvent);
 
     return NextResponse.json({ ok: true });
-  } catch (err) {
-    console.error("Error saving charter event:", err);
+  } catch (error) {
+    console.error("Error saving charter event:", error);
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 },
@@ -61,7 +67,7 @@ export async function POST(req: NextRequest) {
 }
 
 // NEW: return all saved charter events
-export async function GET() {
+export async function GET(): Promise<NextResponse> {
   try {
     const rows = await db
       .select()
@@ -69,8 +75,8 @@ export async function GET() {
       .orderBy(charterEvents.id);
 
     return NextResponse.json(rows);
-  } catch (err) {
-    console.error("Error loading charter events:", err);
+  } catch (error) {
+    console.error("Error loading charter events:", error);
     return NextResponse.json(
       { error: "Failed to load events" },
       { status: 500 },

--- a/src/app/api/ridership/route.ts
+++ b/src/app/api/ridership/route.ts
@@ -1,0 +1,59 @@
+// src/app/api/ridership/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import db from "@/db";
+import { ridershipMetrics } from "@/db/schema";
+
+type RidershipPayload = {
+  reportingMonth: string | null; // ISO string from client
+};
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = (await req.json()) as RidershipPayload;
+    const { reportingMonth } = body;
+
+    if (!reportingMonth) {
+      return NextResponse.json(
+        { error: "reportingMonth is required" },
+        { status: 400 },
+      );
+    }
+
+    await db.insert(ridershipMetrics).values({
+      reportingMonth: new Date(reportingMonth).toISOString().slice(0, 10),
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    console.error("Error saving ridership metric:", err);
+    return NextResponse.json(
+      {
+        error: "Internal server error",
+        ...(process.env.NODE_ENV === "development" && { detail: message }),
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function GET() {
+  try {
+    const rows = await db
+      .select()
+      .from(ridershipMetrics)
+      .orderBy(ridershipMetrics.id);
+
+    return NextResponse.json(rows);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    console.error("Error loading ridership metrics:", err);
+    return NextResponse.json(
+      {
+        error: "Failed to load metrics",
+        ...(process.env.NODE_ENV === "development" && { detail: message }),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/ridership/route.ts
+++ b/src/app/api/ridership/route.ts
@@ -1,5 +1,6 @@
 // src/app/api/ridership/route.ts
 import { NextRequest, NextResponse } from "next/server";
+
 import db from "@/db";
 import { ridershipMetrics } from "@/db/schema";
 
@@ -7,7 +8,7 @@ type RidershipPayload = {
   reportingMonth: string | null; // ISO string from client
 };
 
-export async function POST(req: NextRequest) {
+export async function POST(req: NextRequest): Promise<NextResponse> {
   try {
     const body = (await req.json()) as RidershipPayload;
     const { reportingMonth } = body;
@@ -24,9 +25,9 @@ export async function POST(req: NextRequest) {
     });
 
     return NextResponse.json({ ok: true });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    console.error("Error saving ridership metric:", err);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    console.error("Error saving ridership metric:", error);
     return NextResponse.json(
       {
         error: "Internal server error",
@@ -37,7 +38,7 @@ export async function POST(req: NextRequest) {
   }
 }
 
-export async function GET() {
+export async function GET(): Promise<NextResponse> {
   try {
     const rows = await db
       .select()
@@ -45,9 +46,9 @@ export async function GET() {
       .orderBy(ridershipMetrics.id);
 
     return NextResponse.json(rows);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    console.error("Error loading ridership metrics:", err);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    console.error("Error loading ridership metrics:", error);
     return NextResponse.json(
       {
         error: "Failed to load metrics",

--- a/src/app/departments/charters/page.tsx
+++ b/src/app/departments/charters/page.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
-import type { JSX } from "react";
-
 import {
   Box,
   Button,
@@ -15,9 +12,11 @@ import {
   Typography,
 } from "@mui/material";
 import Grid from "@mui/material/Grid";
-import { LocalizationProvider, DatePicker } from "@mui/x-date-pickers";
+import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import type { Dayjs } from "dayjs";
+import type { JSX } from "react";
+import React, { useEffect, useState } from "react";
 
 const isNonNegative = (value: string): boolean => {
   if (value === "") return true;
@@ -32,6 +31,14 @@ const handleNumericChange = (
   if (value === "" || /^\d*\.?\d*$/.test(value)) {
     setter(value);
   }
+};
+
+type SavedCharterEvent = {
+  id: number;
+  eventType: string;
+  passengerCount: number | null;
+  vehicleHours: number | null;
+  vehicleMiles: number | null;
 };
 
 export default function ChartersPage(): JSX.Element {
@@ -50,7 +57,7 @@ export default function ChartersPage(): JSX.Element {
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitSuccess, setSubmitSuccess] = useState(false);
 
-  const [savedEvents, setSavedEvents] = useState<any[]>([]);
+  const [savedEvents, setSavedEvents] = useState<SavedCharterEvent[]>([]);
 
   const isEventDateRequired = eventType !== "";
   const isEventDateValid = isEventDateRequired ? eventDate !== null : true;
@@ -71,14 +78,14 @@ export default function ChartersPage(): JSX.Element {
     isRevenueTotalValid &&
     isServiceTotalValid;
 
-  async function loadEvents() {
+  async function loadEvents(): Promise<void> {
     try {
       const res = await fetch("/api/charters");
       if (!res.ok) return;
       const data = await res.json();
       setSavedEvents(data);
-    } catch (err) {
-      console.error("[Charters] failed to load events", err);
+    } catch (error) {
+      console.error("[Charters] failed to load events", error);
     }
   }
 
@@ -86,13 +93,10 @@ export default function ChartersPage(): JSX.Element {
     void loadEvents();
   }, []);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
     e.preventDefault();
 
-    console.log("[Charters] submit clicked");
-
     if (!isFormValid) {
-      console.log("[Charters] form invalid");
       return;
     }
 
@@ -112,8 +116,6 @@ export default function ChartersPage(): JSX.Element {
       serviceTotal: serviceTotal ? Number(serviceTotal) : null,
     };
 
-    console.log("[Charters] payload", payload);
-
     try {
       const res = await fetch("/api/charters", {
         method: "POST",
@@ -121,10 +123,7 @@ export default function ChartersPage(): JSX.Element {
         body: JSON.stringify(payload),
       });
 
-      console.log("[Charters] response status", res.status);
-
       const text = await res.text();
-      console.log("[Charters] response body", text);
 
       if (!res.ok) {
         setSubmitError(`Failed to save charter event: ${text}`);
@@ -137,8 +136,8 @@ export default function ChartersPage(): JSX.Element {
 
       // Refresh list of saved events for the demo
       void loadEvents();
-    } catch (err) {
-      console.error("[Charters] network or JS error", err);
+    } catch (error) {
+      console.error("[Charters] network or JS error", error);
       setSubmitError("Unexpected error while saving charter event.");
       alert("Unexpected error while saving charter event.");
     } finally {
@@ -162,12 +161,14 @@ export default function ChartersPage(): JSX.Element {
             <Stack spacing={4}>
               {/* Top row: Reporting Month, Event Type, Event Date */}
               <Grid container spacing={3}>
-                <Grid item xs={12} md={4}>
+                <Grid size={{ xs: 12, md: 4 }}>
                   <DatePicker
                     label="Reporting Month"
                     views={["year", "month"]}
                     value={reportingMonth}
-                    onChange={(newValue) => setReportingMonth(newValue)}
+                    onChange={(newValue) =>
+                      setReportingMonth(newValue as Dayjs | null)
+                    }
                     slotProps={{
                       textField: {
                         fullWidth: true,
@@ -177,7 +178,7 @@ export default function ChartersPage(): JSX.Element {
                   />
                 </Grid>
 
-                <Grid item xs={12} md={4}>
+                <Grid size={{ xs: 12, md: 4 }}>
                   <FormControl fullWidth>
                     <InputLabel id="event-type-label">Event Type</InputLabel>
                     <Select
@@ -195,11 +196,13 @@ export default function ChartersPage(): JSX.Element {
                   </FormControl>
                 </Grid>
 
-                <Grid item xs={12} md={4}>
+                <Grid size={{ xs: 12, md: 4 }}>
                   <DatePicker
                     label="Event Date"
                     value={eventDate}
-                    onChange={(newValue) => setEventDate(newValue)}
+                    onChange={(newValue) =>
+                      setEventDate(newValue as Dayjs | null)
+                    }
                     slotProps={{
                       textField: {
                         fullWidth: true,
@@ -216,7 +219,7 @@ export default function ChartersPage(): JSX.Element {
 
               {/* Numeric Fields: Passenger Count, Vehicle Hours, Vehicle Miles */}
               <Grid container spacing={3}>
-                <Grid item xs={12} md={4}>
+                <Grid size={{ xs: 12, md: 4 }}>
                   <TextField
                     label="Passenger Count"
                     type="number"
@@ -235,7 +238,7 @@ export default function ChartersPage(): JSX.Element {
                   />
                 </Grid>
 
-                <Grid item xs={12} md={4}>
+                <Grid size={{ xs: 12, md: 4 }}>
                   <TextField
                     label="Vehicle Hours"
                     type="number"
@@ -254,7 +257,7 @@ export default function ChartersPage(): JSX.Element {
                   />
                 </Grid>
 
-                <Grid item xs={12} md={4}>
+                <Grid size={{ xs: 12, md: 4 }}>
                   <TextField
                     label="Vehicle Miles"
                     type="number"
@@ -276,7 +279,7 @@ export default function ChartersPage(): JSX.Element {
 
               {/* Driver Assignments */}
               <Grid container spacing={3}>
-                <Grid item xs={12}>
+                <Grid size={{ xs: 12 }}>
                   <TextField
                     label="Driver Assignments"
                     value={driverAssignments}
@@ -290,7 +293,7 @@ export default function ChartersPage(): JSX.Element {
 
               {/* Revenue & Service Totals */}
               <Grid container spacing={3}>
-                <Grid item xs={12} md={6}>
+                <Grid size={{ xs: 12, md: 6 }}>
                   <TextField
                     label="Revenue Total"
                     type="number"
@@ -309,7 +312,7 @@ export default function ChartersPage(): JSX.Element {
                   />
                 </Grid>
 
-                <Grid item xs={12} md={6}>
+                <Grid size={{ xs: 12, md: 6 }}>
                   <TextField
                     label="Service Total"
                     type="number"
@@ -346,7 +349,11 @@ export default function ChartersPage(): JSX.Element {
                 )}
 
                 {submitSuccess && (
-                  <Typography color="success.main" variant="body2" sx={{ mt: 1 }}>
+                  <Typography
+                    color="success.main"
+                    variant="body2"
+                    sx={{ mt: 1 }}
+                  >
                     Saved successfully.
                   </Typography>
                 )}
@@ -361,12 +368,10 @@ export default function ChartersPage(): JSX.Element {
             </Typography>
 
             {savedEvents.length === 0 ? (
-              <Typography variant="body2">
-                No events saved yet.
-              </Typography>
+              <Typography variant="body2">No events saved yet.</Typography>
             ) : (
               <Box component="ul" sx={{ pl: 3 }}>
-                {savedEvents.map((evt: any) => (
+                {savedEvents.map((evt) => (
                   <li key={evt.id}>
                     {evt.eventType} — {evt.passengerCount ?? 0} passengers,{" "}
                     {evt.vehicleHours ?? 0} hours, {evt.vehicleMiles ?? 0} miles

--- a/src/app/departments/hr/page.tsx
+++ b/src/app/departments/hr/page.tsx
@@ -1,14 +1,28 @@
 "use client";
 
-import React, { useState } from "react";
-import Link from "next/link";
 import { TextField } from "@mui/material";
 import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+import Link from "next/link";
+import type { JSX } from "react";
+import React, { useState } from "react";
 
-export default function HR() {
-  const [month, setMonth] = useState(null);
-  const [form, setForm] = useState({
+type HrFieldKey =
+  | "weekday"
+  | "saturday"
+  | "sunday"
+  | "system"
+  | "vehicles"
+  | "driverHours"
+  | "overtime"
+  | "absenteeism"
+  | "training";
+
+type HrFormState = Record<HrFieldKey, string>;
+
+export default function HR(): JSX.Element {
+  const [month, setMonth] = useState<Date | null>(null);
+  const [form, setForm] = useState<HrFormState>({
     weekday: "",
     saturday: "",
     sunday: "",
@@ -17,59 +31,58 @@ export default function HR() {
     driverHours: "",
     overtime: "",
     absenteeism: "",
-    training: ""
+    training: "",
   });
 
-  const handle = (k: string, v: string) => setForm({ ...form, [k]: v });
+  const handle = (k: HrFieldKey, v: string): void =>
+    setForm((prev) => ({ ...prev, [k]: v }));
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
-    <div style={{ padding: "1rem" }}>
-      <h1>HR / Operations Metrics</h1>
+      <div style={{ padding: "1rem" }}>
+        <h1>HR / Operations Metrics</h1>
 
-      <DatePicker
-        label="Reporting Month"
-        views={["year", "month"]}
-        value={month}
-        onChange={setMonth}
-      />
+        <DatePicker
+          label="Reporting Month"
+          views={["year", "month"]}
+          value={month}
+          onChange={(newValue) => setMonth(newValue as Date | null)}
+        />
 
-      {[
-        { l: "OTP Weekday", k: "weekday" },
-        { l: "OTP Saturday", k: "saturday" },
-        { l: "OTP Sunday", k: "sunday" },
-        { l: "OTP System", k: "system" },
-        { l: "Peak Vehicles", k: "vehicles" },
-        { l: "Driver Hours", k: "driverHours" },
-        { l: "Overtime Hours", k: "overtime" },
-        { l: "Absenteeism", k: "absenteeism" }
-      ].map(({ l, k }) => (
+        {[
+          { l: "OTP Weekday", k: "weekday" as HrFieldKey },
+          { l: "OTP Saturday", k: "saturday" as HrFieldKey },
+          { l: "OTP Sunday", k: "sunday" as HrFieldKey },
+          { l: "OTP System", k: "system" as HrFieldKey },
+          { l: "Peak Vehicles", k: "vehicles" as HrFieldKey },
+          { l: "Driver Hours", k: "driverHours" as HrFieldKey },
+          { l: "Overtime Hours", k: "overtime" as HrFieldKey },
+          { l: "Absenteeism", k: "absenteeism" as HrFieldKey },
+        ].map(({ l, k }) => (
+          <TextField
+            key={k}
+            label={l}
+            type="number"
+            value={form[k]}
+            onChange={(e) => handle(k, e.target.value)}
+            inputProps={{ min: 0, max: k.includes("otp") ? 100 : undefined }}
+            style={{ display: "block", margin: "0.5rem 0" }}
+          />
+        ))}
+
         <TextField
-          key={k}
-          label={l}
-          type="number"
-          value={(form as any)[k]}
-          onChange={(e) => handle(k, e.target.value)}
-          inputProps={{ min: 0, max: k.includes("otp") ? 100 : undefined }}
+          label="Training / Certifications"
+          multiline
+          minRows={2}
+          value={form.training}
+          onChange={(e) => handle("training", e.target.value)}
           style={{ display: "block", margin: "0.5rem 0" }}
         />
-      ))}
 
-      <TextField
-        label="Training / Certifications"
-        multiline
-        minRows={2}
-        value={form.training}
-        onChange={(e) => handle("training", e.target.value)}
-        style={{ display: "block", margin: "0.5rem 0" }}
-      />
-import Link from "next/link";
-import React, { FC } from "react";
-
-      <p>
-        <Link href="/">← Home</Link>
-      </p>
-    </div>
+        <p>
+          <Link href="/">← Home</Link>
+        </p>
+      </div>
     </LocalizationProvider>
   );
 }

--- a/src/app/departments/lift/page.tsx
+++ b/src/app/departments/lift/page.tsx
@@ -97,7 +97,7 @@ export default function LiftPage(): JSX.Element {
 
             {/* Trips + Passengers */}
             <Grid container spacing={3}>
-              <Grid container item xs={12} md={3}>
+              <Grid item xs={12} md={3}>
                 <TextField
                   label="Trips Denied"
                   type="number"
@@ -116,7 +116,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid container item xs={12} md={3}>
+              <Grid item xs={12} md={3}>
                 <TextField
                   label="No-Shows"
                   type="number"
@@ -135,7 +135,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid container item xs={12} md={3}>
+              <Grid item xs={12} md={3}>
                 <TextField
                   label="Trips Scheduled"
                   type="number"
@@ -176,7 +176,7 @@ export default function LiftPage(): JSX.Element {
 
             {/* Revenue Miles / Hours */}
             <Grid container spacing={3}>
-              <Grid container item xs={12} md={4}>
+              <Grid item xs={12} md={4}>
                 <TextField
                   label="Revenue Vehicle Miles"
                   type="number"
@@ -195,7 +195,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid container item xs={12} md={4}>
+              <Grid item xs={12} md={4}>
                 <TextField
                   label="Revenue Vehicle Hours"
                   type="number"
@@ -214,7 +214,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid container item xs={12} md={4}>
+              <Grid item xs={12} md={4}>
                 <TextField
                   label="Average Cost per Trip"
                   type="number"
@@ -236,7 +236,7 @@ export default function LiftPage(): JSX.Element {
 
             {/* Passenger per Mile / Hour + OTP */}
             <Grid container spacing={3}>
-              <Grid container item xs={12} md={4}>
+              <Grid item xs={12} md={4}>
                 <TextField
                   label="Passengers per Mile"
                   type="number"
@@ -255,7 +255,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid container item xs={12} md={4}>
+              <Grid item xs={12} md={4}>
                 <TextField
                   label="Passengers per Hour"
                   type="number"
@@ -274,7 +274,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid container item xs={12} md={4}>
+              <Grid item xs={12} md={4}>
                 <TextField
                   label="On-Time Performance %"
                   type="number"
@@ -296,7 +296,7 @@ export default function LiftPage(): JSX.Element {
 
             {/* Average Ridership (Weekday / Sat / Sun) */}
             <Grid container spacing={3}>
-              <Grid container item xs={12} md={4}>
+              <Grid item xs={12} md={4}>
                 <TextField
                   label="Avg. Weekday Ridership"
                   type="number"
@@ -315,7 +315,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid container item xs={12} md={4}>
+              <Grid item xs={12} md={4}>
                 <TextField
                   label="Avg. Saturday Ridership"
                   type="number"
@@ -337,7 +337,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid container item xs={12} md={4}>
+              <Grid item xs={12} md={4}>
                 <TextField
                   label="Avg. Sunday Ridership"
                   type="number"
@@ -359,7 +359,7 @@ export default function LiftPage(): JSX.Element {
 
             {/* Total Ridership (Weekday / Sat / Sun) */}
             <Grid container spacing={3}>
-              <Grid container item xs={12} md={4}>
+              <Grid item xs={12} md={4}>
                 <TextField
                   label="Total Weekday Ridership"
                   type="number"
@@ -381,7 +381,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid container item xs={12} md={4}>
+              <Grid item xs={12} md={4}>
                 <TextField
                   label="Total Saturday Ridership"
                   type="number"
@@ -403,7 +403,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid container item xs={12} md={4}>
+              <Grid item xs={12} md={4}>
                 <TextField
                   label="Total Sunday Ridership"
                   type="number"

--- a/src/app/departments/lift/page.tsx
+++ b/src/app/departments/lift/page.tsx
@@ -97,7 +97,7 @@ export default function LiftPage(): JSX.Element {
 
             {/* Trips + Passengers */}
             <Grid container spacing={3}>
-              <Grid item xs={12} md={3}>
+              <Grid container item xs={12} md={3}>
                 <TextField
                   label="Trips Denied"
                   type="number"
@@ -116,7 +116,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={3}>
+              <Grid container item xs={12} md={3}>
                 <TextField
                   label="No-Shows"
                   type="number"
@@ -135,7 +135,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={3}>
+              <Grid container item xs={12} md={3}>
                 <TextField
                   label="Trips Scheduled"
                   type="number"
@@ -176,7 +176,7 @@ export default function LiftPage(): JSX.Element {
 
             {/* Revenue Miles / Hours */}
             <Grid container spacing={3}>
-              <Grid item xs={12} md={4}>
+              <Grid container item xs={12} md={4}>
                 <TextField
                   label="Revenue Vehicle Miles"
                   type="number"
@@ -195,7 +195,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={4}>
+              <Grid container item xs={12} md={4}>
                 <TextField
                   label="Revenue Vehicle Hours"
                   type="number"
@@ -214,7 +214,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={4}>
+              <Grid container item xs={12} md={4}>
                 <TextField
                   label="Average Cost per Trip"
                   type="number"
@@ -236,7 +236,7 @@ export default function LiftPage(): JSX.Element {
 
             {/* Passenger per Mile / Hour + OTP */}
             <Grid container spacing={3}>
-              <Grid item xs={12} md={4}>
+              <Grid container item xs={12} md={4}>
                 <TextField
                   label="Passengers per Mile"
                   type="number"
@@ -255,7 +255,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={4}>
+              <Grid container item xs={12} md={4}>
                 <TextField
                   label="Passengers per Hour"
                   type="number"
@@ -274,7 +274,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={4}>
+              <Grid container item xs={12} md={4}>
                 <TextField
                   label="On-Time Performance %"
                   type="number"
@@ -296,7 +296,7 @@ export default function LiftPage(): JSX.Element {
 
             {/* Average Ridership (Weekday / Sat / Sun) */}
             <Grid container spacing={3}>
-              <Grid item xs={12} md={4}>
+              <Grid container item xs={12} md={4}>
                 <TextField
                   label="Avg. Weekday Ridership"
                   type="number"
@@ -315,7 +315,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={4}>
+              <Grid container item xs={12} md={4}>
                 <TextField
                   label="Avg. Saturday Ridership"
                   type="number"
@@ -337,7 +337,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={4}>
+              <Grid container item xs={12} md={4}>
                 <TextField
                   label="Avg. Sunday Ridership"
                   type="number"
@@ -359,7 +359,7 @@ export default function LiftPage(): JSX.Element {
 
             {/* Total Ridership (Weekday / Sat / Sun) */}
             <Grid container spacing={3}>
-              <Grid item xs={12} md={4}>
+              <Grid container item xs={12} md={4}>
                 <TextField
                   label="Total Weekday Ridership"
                   type="number"
@@ -381,7 +381,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={4}>
+              <Grid container item xs={12} md={4}>
                 <TextField
                   label="Total Saturday Ridership"
                   type="number"
@@ -403,7 +403,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={4}>
+              <Grid container item xs={12} md={4}>
                 <TextField
                   label="Total Sunday Ridership"
                   type="number"

--- a/src/app/departments/lift/page.tsx
+++ b/src/app/departments/lift/page.tsx
@@ -1,22 +1,11 @@
 "use client";
 
-import React, { useState } from "react";
-import type { JSX } from "react";
-
-import {
-  Box,
-  Button,
-  Grid,
-  Stack,
-  TextField,
-  Typography,
-} from "@mui/material";
-import {
-  LocalizationProvider,
-  DatePicker,
-} from "@mui/x-date-pickers";
+import { Box, Button, Grid, Stack, TextField, Typography } from "@mui/material";
+import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import type { Dayjs } from "dayjs";
+import type { JSX } from "react";
+import React, { useState } from "react";
 
 const isNonNegative = (value: string): boolean => {
   if (value === "") return true;
@@ -60,8 +49,10 @@ export default function LiftPage(): JSX.Element {
   const [avgSaturdayRidership, setAvgSaturdayRidership] = useState<string>("");
   const [avgSundayRidership, setAvgSundayRidership] = useState<string>("");
 
-  const [totalWeekdayRidership, setTotalWeekdayRidership] = useState<string>("");
-  const [totalSaturdayRidership, setTotalSaturdayRidership] = useState<string>("");
+  const [totalWeekdayRidership, setTotalWeekdayRidership] =
+    useState<string>("");
+  const [totalSaturdayRidership, setTotalSaturdayRidership] =
+    useState<string>("");
   const [totalSundayRidership, setTotalSundayRidership] = useState<string>("");
 
   const [avgCostPerTrip, setAvgCostPerTrip] = useState<string>("");
@@ -85,7 +76,9 @@ export default function LiftPage(): JSX.Element {
                 label="Reporting Month"
                 views={["year", "month"]}
                 value={reportingMonth}
-                onChange={(newValue) => setReportingMonth(newValue)}
+                onChange={(newValue) =>
+                  setReportingMonth(newValue as Dayjs | null)
+                }
                 slotProps={{
                   textField: {
                     fullWidth: true,
@@ -97,7 +90,7 @@ export default function LiftPage(): JSX.Element {
 
             {/* Trips + Passengers */}
             <Grid container spacing={3}>
-              <Grid item xs={12} md={3}>
+              <Grid size={{ xs: 12, md: 3 }}>
                 <TextField
                   label="Trips Denied"
                   type="number"
@@ -116,7 +109,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={3}>
+              <Grid size={{ xs: 12, md: 3 }}>
                 <TextField
                   label="No-Shows"
                   type="number"
@@ -135,7 +128,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={3}>
+              <Grid size={{ xs: 12, md: 3 }}>
                 <TextField
                   label="Trips Scheduled"
                   type="number"
@@ -154,7 +147,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={3}>
+              <Grid size={{ xs: 12, md: 3 }}>
                 <TextField
                   label="Total Passengers"
                   type="number"
@@ -176,7 +169,7 @@ export default function LiftPage(): JSX.Element {
 
             {/* Revenue Miles / Hours */}
             <Grid container spacing={3}>
-              <Grid item xs={12} md={4}>
+              <Grid size={{ xs: 12, md: 4 }}>
                 <TextField
                   label="Revenue Vehicle Miles"
                   type="number"
@@ -195,7 +188,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={4}>
+              <Grid size={{ xs: 12, md: 4 }}>
                 <TextField
                   label="Revenue Vehicle Hours"
                   type="number"
@@ -214,7 +207,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={4}>
+              <Grid size={{ xs: 12, md: 4 }}>
                 <TextField
                   label="Average Cost per Trip"
                   type="number"
@@ -236,7 +229,7 @@ export default function LiftPage(): JSX.Element {
 
             {/* Passenger per Mile / Hour + OTP */}
             <Grid container spacing={3}>
-              <Grid item xs={12} md={4}>
+              <Grid size={{ xs: 12, md: 4 }}>
                 <TextField
                   label="Passengers per Mile"
                   type="number"
@@ -255,7 +248,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={4}>
+              <Grid size={{ xs: 12, md: 4 }}>
                 <TextField
                   label="Passengers per Hour"
                   type="number"
@@ -274,7 +267,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={4}>
+              <Grid size={{ xs: 12, md: 4 }}>
                 <TextField
                   label="On-Time Performance %"
                   type="number"
@@ -284,9 +277,7 @@ export default function LiftPage(): JSX.Element {
                   }
                   error={!isPercent(otpPercent)}
                   helperText={
-                    isPercent(otpPercent)
-                      ? ""
-                      : "Must be between 0 and 100."
+                    isPercent(otpPercent) ? "" : "Must be between 0 and 100."
                   }
                   fullWidth
                   inputProps={{ min: 0, max: 100 }}
@@ -296,7 +287,7 @@ export default function LiftPage(): JSX.Element {
 
             {/* Average Ridership (Weekday / Sat / Sun) */}
             <Grid container spacing={3}>
-              <Grid item xs={12} md={4}>
+              <Grid size={{ xs: 12, md: 4 }}>
                 <TextField
                   label="Avg. Weekday Ridership"
                   type="number"
@@ -315,16 +306,13 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={4}>
+              <Grid size={{ xs: 12, md: 4 }}>
                 <TextField
                   label="Avg. Saturday Ridership"
                   type="number"
                   value={avgSaturdayRidership}
                   onChange={(e) =>
-                    handleNumericChange(
-                      e.target.value,
-                      setAvgSaturdayRidership,
-                    )
+                    handleNumericChange(e.target.value, setAvgSaturdayRidership)
                   }
                   error={!isNonNegative(avgSaturdayRidership)}
                   helperText={
@@ -337,7 +325,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={4}>
+              <Grid size={{ xs: 12, md: 4 }}>
                 <TextField
                   label="Avg. Sunday Ridership"
                   type="number"
@@ -359,7 +347,7 @@ export default function LiftPage(): JSX.Element {
 
             {/* Total Ridership (Weekday / Sat / Sun) */}
             <Grid container spacing={3}>
-              <Grid item xs={12} md={4}>
+              <Grid size={{ xs: 12, md: 4 }}>
                 <TextField
                   label="Total Weekday Ridership"
                   type="number"
@@ -381,7 +369,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={4}>
+              <Grid size={{ xs: 12, md: 4 }}>
                 <TextField
                   label="Total Saturday Ridership"
                   type="number"
@@ -403,7 +391,7 @@ export default function LiftPage(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={4}>
+              <Grid size={{ xs: 12, md: 4 }}>
                 <TextField
                   label="Total Sunday Ridership"
                   type="number"

--- a/src/app/departments/maintenance/page.tsx
+++ b/src/app/departments/maintenance/page.tsx
@@ -1,18 +1,14 @@
 "use client";
 
-import Link from "next/link";
-import React, { useState } from "react";
-import {
-  Box,
-  TextField,
-  Typography,
-  Paper,
-} from "@mui/material";
+import { Box, Paper, TextField, Typography } from "@mui/material";
 import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import type { Dayjs } from "dayjs";
+import Link from "next/link";
+import type { JSX } from "react";
+import React, { useState } from "react";
 
-export default function Maintenance() {
+export default function Maintenance(): JSX.Element {
   const [reportingMonth, setReportingMonth] = useState<Dayjs | null>(null);
   const [values, setValues] = useState({
     motorBusMajor: "",
@@ -25,7 +21,7 @@ export default function Maintenance() {
     electric: "",
   });
 
-  const handleChange = (field: string, value: string) => {
+  const handleChange = (field: string, value: string): void => {
     if (/^\d*$/.test(value)) {
       setValues((prev) => ({ ...prev, [field]: value }));
     }
@@ -36,13 +32,11 @@ export default function Maintenance() {
       <Box sx={{ p: 4, mb: 4 }}>
         <h1 className="text-3xl font-bold">Maintenance page</h1>
         <p className="text-gray-700">
-          This is the page that will display Maintenance metrics and future inputs.
+          This is the page that will display Maintenance metrics and future
+          inputs.
         </p>
 
-        <Link
-          href="/"
-          className="text-blue-600 hover:underline block mt-8"
-        >
+        <Link href="/" className="text-blue-600 hover:underline block mt-8">
           ← Back to Home
         </Link>
       </Box>
@@ -146,7 +140,6 @@ export default function Maintenance() {
           </Paper>
         </Box>
       </LocalizationProvider>
-      
     </main>
   );
 }

--- a/src/app/departments/maintenance/page.tsx
+++ b/src/app/departments/maintenance/page.tsx
@@ -9,10 +9,11 @@ import {
   Paper,
 } from "@mui/material";
 import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
-import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import type { Dayjs } from "dayjs";
 
 export default function Maintenance() {
-  const [reportingMonth, setReportingMonth] = useState<Date | null>(new Date());
+  const [reportingMonth, setReportingMonth] = useState<Dayjs | null>(null);
   const [values, setValues] = useState({
     motorBusMajor: "",
     motorBusOther: "",
@@ -45,7 +46,7 @@ export default function Maintenance() {
           ← Back to Home
         </Link>
       </Box>
-      <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <LocalizationProvider dateAdapter={AdapterDayjs}>
         <Box p={4}>
           <Paper elevation={3} sx={{ p: 4 }}>
             <Typography variant="h5" gutterBottom>
@@ -58,7 +59,9 @@ export default function Maintenance() {
                 views={["year", "month"]}
                 label="Reporting Month"
                 value={reportingMonth}
-                onChange={(newValue) => setReportingMonth(newValue)}
+                onChange={(newValue) =>
+                  setReportingMonth(newValue as Dayjs | null)
+                }
                 slotProps={{ textField: { fullWidth: true } }}
               />
             </Box>

--- a/src/app/departments/ridership/page.tsx
+++ b/src/app/departments/ridership/page.tsx
@@ -1,16 +1,160 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import type { JSX } from "react";
 import Link from "next/link";
-import { JSX } from "react";
 
-export default function Home(): JSX.Element {
+import { Box, Button, Stack, Typography } from "@mui/material";
+import Grid from "@mui/material/Grid";
+import { LocalizationProvider, DatePicker } from "@mui/x-date-pickers";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import type { Dayjs } from "dayjs";
+
+export default function RidershipPage(): JSX.Element {
+  const [reportingMonth, setReportingMonth] = useState<Dayjs | null>(null);
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitSuccess, setSubmitSuccess] = useState(false);
+
+  const [savedMetrics, setSavedMetrics] = useState<
+    { id: number; reportingMonth: string; createdAt?: string }[]
+  >([]);
+
+  const isFormValid = reportingMonth !== null;
+
+  async function loadMetrics() {
+    try {
+      const res = await fetch("/api/ridership");
+      if (!res.ok) return;
+      const data = await res.json();
+      setSavedMetrics(data);
+    } catch (err) {
+      console.error("[Ridership] failed to load metrics", err);
+    }
+  }
+
+  useEffect(() => {
+    void loadMetrics();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!isFormValid) return;
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+    setSubmitSuccess(false);
+
+    const payload = {
+      reportingMonth: reportingMonth?.toISOString() ?? null,
+    };
+
+    try {
+      const res = await fetch("/api/ridership", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      const text = await res.text();
+
+      if (!res.ok) {
+        setSubmitError(`Failed to save ridership metric: ${text}`);
+        return;
+      }
+
+      setSubmitSuccess(true);
+      void loadMetrics();
+    } catch (err) {
+      console.error("[Ridership] network or JS error", err);
+      setSubmitError("Unexpected error while saving ridership metric.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
-    <main className="p-6">
-      <h1 className="text-3xl font-bold mb-4">
-        Ridership and System Performance
-      </h1>
+    <main>
+      <LocalizationProvider dateAdapter={AdapterDayjs}>
+        <Box sx={{ p: 4 }}>
+          <Link href="/" className="text-blue-500 hover:underline">
+            ← Back to Home
+          </Link>
 
-      <Link href="/" className="text-blue-500 hover:underline">
-        ← Back to Home
-      </Link>
+          <Typography variant="h4" gutterBottom sx={{ mt: 2 }}>
+            Ridership and System Performance
+          </Typography>
+
+          <Typography variant="body1" sx={{ mb: 3 }}>
+            Enter monthly ridership metrics for the selected reporting month.
+          </Typography>
+
+          <Box component="form" onSubmit={handleSubmit}>
+            <Stack spacing={4}>
+              <Grid container spacing={3}>
+                <Grid size={{ xs: 12, md: 4 }}>
+                  <DatePicker
+                    label="Reporting Month"
+                    views={["year", "month"]}
+                    value={reportingMonth}
+                    onChange={(newValue) =>
+                      setReportingMonth(newValue as Dayjs | null)
+                    }
+                    slotProps={{
+                      textField: {
+                        fullWidth: true,
+                        required: true,
+                      },
+                    }}
+                  />
+                </Grid>
+              </Grid>
+
+              <Box>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  disabled={!isFormValid || isSubmitting}
+                >
+                  {isSubmitting ? "Saving..." : "Save"}
+                </Button>
+
+                {submitError && (
+                  <Typography color="error" variant="body2" sx={{ mt: 1 }}>
+                    {submitError}
+                  </Typography>
+                )}
+
+                {submitSuccess && (
+                  <Typography color="success.main" variant="body2" sx={{ mt: 1 }}>
+                    Saved successfully.
+                  </Typography>
+                )}
+              </Box>
+            </Stack>
+          </Box>
+
+          <Box sx={{ mt: 6 }}>
+            <Typography variant="h5" gutterBottom>
+              Saved Entries
+            </Typography>
+
+            {savedMetrics.length === 0 ? (
+              <Typography variant="body2">No entries saved yet.</Typography>
+            ) : (
+              <Box component="ul" sx={{ pl: 3 }}>
+                {savedMetrics.map((m) => (
+                  <li key={m.id}>
+                    Reporting month: {m.reportingMonth}
+                  </li>
+                ))}
+              </Box>
+            )}
+          </Box>
+        </Box>
+      </LocalizationProvider>
     </main>
   );
 }

--- a/src/app/departments/ridership/page.tsx
+++ b/src/app/departments/ridership/page.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
-import type { JSX } from "react";
-import Link from "next/link";
-
 import { Box, Button, Stack, Typography } from "@mui/material";
 import Grid from "@mui/material/Grid";
-import { LocalizationProvider, DatePicker } from "@mui/x-date-pickers";
+import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import type { Dayjs } from "dayjs";
+import Link from "next/link";
+import type { JSX } from "react";
+import React, { useEffect, useState } from "react";
 
 export default function RidershipPage(): JSX.Element {
   const [reportingMonth, setReportingMonth] = useState<Dayjs | null>(null);
@@ -23,14 +22,14 @@ export default function RidershipPage(): JSX.Element {
 
   const isFormValid = reportingMonth !== null;
 
-  async function loadMetrics() {
+  async function loadMetrics(): Promise<void> {
     try {
       const res = await fetch("/api/ridership");
       if (!res.ok) return;
       const data = await res.json();
       setSavedMetrics(data);
-    } catch (err) {
-      console.error("[Ridership] failed to load metrics", err);
+    } catch (error) {
+      console.error("[Ridership] failed to load metrics", error);
     }
   }
 
@@ -38,7 +37,7 @@ export default function RidershipPage(): JSX.Element {
     void loadMetrics();
   }, []);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
     e.preventDefault();
 
     if (!isFormValid) return;
@@ -67,8 +66,8 @@ export default function RidershipPage(): JSX.Element {
 
       setSubmitSuccess(true);
       void loadMetrics();
-    } catch (err) {
-      console.error("[Ridership] network or JS error", err);
+    } catch (error) {
+      console.error("[Ridership] network or JS error", error);
       setSubmitError("Unexpected error while saving ridership metric.");
     } finally {
       setIsSubmitting(false);
@@ -128,7 +127,11 @@ export default function RidershipPage(): JSX.Element {
                 )}
 
                 {submitSuccess && (
-                  <Typography color="success.main" variant="body2" sx={{ mt: 1 }}>
+                  <Typography
+                    color="success.main"
+                    variant="body2"
+                    sx={{ mt: 1 }}
+                  >
                     Saved successfully.
                   </Typography>
                 )}
@@ -146,9 +149,7 @@ export default function RidershipPage(): JSX.Element {
             ) : (
               <Box component="ul" sx={{ pl: 3 }}>
                 {savedMetrics.map((m) => (
-                  <li key={m.id}>
-                    Reporting month: {m.reportingMonth}
-                  </li>
+                  <li key={m.id}>Reporting month: {m.reportingMonth}</li>
                 ))}
               </Box>
             )}

--- a/src/app/departments/safety/page.tsx
+++ b/src/app/departments/safety/page.tsx
@@ -62,7 +62,7 @@ export default function Safety(): JSX.Element {
                 label="Reporting Month"
                 views={["year", "month"]}
                 value={reportingMonth}
-                onChange={(newValue) => setReportingMonth(newValue)}
+                onChange={(newValue) => setReportingMonth(newValue as Dayjs | null)}
                 slotProps={{
                   textField: {
                     fullWidth: true,
@@ -74,7 +74,7 @@ export default function Safety(): JSX.Element {
 
             {/* Preventable Accidents */}
             <Grid container spacing={3}>
-              <Grid container item xs={12} md={6}>
+              <Grid item xs={12} md={6}>
                 <TextField
                   label="Preventable Accidents — Main Line"
                   type="number"
@@ -93,7 +93,7 @@ export default function Safety(): JSX.Element {
                 />
               </Grid>
 
-              <Grid container item xs={12} md={6}>
+              <Grid item xs={12} md={6}>
                 <TextField
                   label="Preventable Accidents — Lift"
                   type="number"
@@ -115,7 +115,7 @@ export default function Safety(): JSX.Element {
 
             {/* Collisions */}
             <Grid container spacing={3}>
-              <Grid container item xs={12} md={6}>
+              <Grid item xs={12} md={6}>
                 <TextField
                   label="Collisions — Main Line"
                   type="number"
@@ -134,7 +134,7 @@ export default function Safety(): JSX.Element {
                 />
               </Grid>
 
-              <Grid container item xs={12} md={6}>
+              <Grid item xs={12} md={6}>
                 <TextField
                   label="Collisions — Lift"
                   type="number"
@@ -156,7 +156,7 @@ export default function Safety(): JSX.Element {
 
             {/* Notes */}
             <Grid container spacing={3}>
-              <Grid container item xs={12}>
+              <Grid item xs={12}>
                 <TextField
                   label="Notes"
                   value={notes}

--- a/src/app/departments/safety/page.tsx
+++ b/src/app/departments/safety/page.tsx
@@ -1,22 +1,11 @@
 "use client";
 
-import React, { useState } from "react";
-import type { JSX } from "react";
-
-import {
-  Box,
-  Button,
-  Grid,
-  Stack,
-  TextField,
-  Typography,
-} from "@mui/material";
-import {
-  LocalizationProvider,
-  DatePicker,
-} from "@mui/x-date-pickers";
+import { Box, Button, Grid, Stack, TextField, Typography } from "@mui/material";
+import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import type { Dayjs } from "dayjs";
+import type { JSX } from "react";
+import React, { useState } from "react";
 
 const isNonNegative = (value: string): boolean => {
   if (value === "") return true;
@@ -52,7 +41,8 @@ export default function Safety(): JSX.Element {
           </Typography>
 
           <Typography variant="body1" sx={{ mb: 3 }}>
-            Enter monthly Safety metrics for preventable accidents and collisions.
+            Enter monthly Safety metrics for preventable accidents and
+            collisions.
           </Typography>
 
           <Stack spacing={4}>
@@ -62,7 +52,9 @@ export default function Safety(): JSX.Element {
                 label="Reporting Month"
                 views={["year", "month"]}
                 value={reportingMonth}
-                onChange={(newValue) => setReportingMonth(newValue as Dayjs | null)}
+                onChange={(newValue) =>
+                  setReportingMonth(newValue as Dayjs | null)
+                }
                 slotProps={{
                   textField: {
                     fullWidth: true,
@@ -74,7 +66,7 @@ export default function Safety(): JSX.Element {
 
             {/* Preventable Accidents */}
             <Grid container spacing={3}>
-              <Grid item xs={12} md={6}>
+              <Grid size={{ xs: 12, md: 6 }}>
                 <TextField
                   label="Preventable Accidents — Main Line"
                   type="number"
@@ -93,7 +85,7 @@ export default function Safety(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={6}>
+              <Grid size={{ xs: 12, md: 6 }}>
                 <TextField
                   label="Preventable Accidents — Lift"
                   type="number"
@@ -115,7 +107,7 @@ export default function Safety(): JSX.Element {
 
             {/* Collisions */}
             <Grid container spacing={3}>
-              <Grid item xs={12} md={6}>
+              <Grid size={{ xs: 12, md: 6 }}>
                 <TextField
                   label="Collisions — Main Line"
                   type="number"
@@ -134,7 +126,7 @@ export default function Safety(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={6}>
+              <Grid size={{ xs: 12, md: 6 }}>
                 <TextField
                   label="Collisions — Lift"
                   type="number"
@@ -156,7 +148,7 @@ export default function Safety(): JSX.Element {
 
             {/* Notes */}
             <Grid container spacing={3}>
-              <Grid item xs={12}>
+              <Grid size={{ xs: 12 }}>
                 <TextField
                   label="Notes"
                   value={notes}

--- a/src/app/departments/safety/page.tsx
+++ b/src/app/departments/safety/page.tsx
@@ -74,7 +74,7 @@ export default function Safety(): JSX.Element {
 
             {/* Preventable Accidents */}
             <Grid container spacing={3}>
-              <Grid item xs={12} md={6}>
+              <Grid container item xs={12} md={6}>
                 <TextField
                   label="Preventable Accidents — Main Line"
                   type="number"
@@ -93,7 +93,7 @@ export default function Safety(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={6}>
+              <Grid container item xs={12} md={6}>
                 <TextField
                   label="Preventable Accidents — Lift"
                   type="number"
@@ -115,7 +115,7 @@ export default function Safety(): JSX.Element {
 
             {/* Collisions */}
             <Grid container spacing={3}>
-              <Grid item xs={12} md={6}>
+              <Grid container item xs={12} md={6}>
                 <TextField
                   label="Collisions — Main Line"
                   type="number"
@@ -134,7 +134,7 @@ export default function Safety(): JSX.Element {
                 />
               </Grid>
 
-              <Grid item xs={12} md={6}>
+              <Grid container item xs={12} md={6}>
                 <TextField
                   label="Collisions — Lift"
                   type="number"
@@ -156,7 +156,7 @@ export default function Safety(): JSX.Element {
 
             {/* Notes */}
             <Grid container spacing={3}>
-              <Grid item xs={12}>
+              <Grid container item xs={12}>
                 <TextField
                   label="Notes"
                   value={notes}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,13 +23,21 @@ export default function HomePage(): ReactNode {
         </Typography>
 
         <Stack spacing={2}>
-          <Button component={Link} href="/departments/charters" variant="contained">
+          <Button
+            component={Link}
+            href="/departments/charters"
+            variant="contained"
+          >
             Charters
           </Button>
           <Button component={Link} href="/departments/lift" variant="contained">
             Lift
           </Button>
-          <Button component={Link} href="/departments/safety" variant="contained">
+          <Button
+            component={Link}
+            href="/departments/safety"
+            variant="contained"
+          >
             Safety
           </Button>
           <Button

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,6 +1,7 @@
 // src/db/index.ts
 import { neon } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-http";
+
 import * as schema from "./schema";
 
 const sql = neon(process.env.DATABASE_URL!);

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -88,3 +88,13 @@ import {
       .notNull(),
   });
   
+  /* ======================
+   RIDERSHIP METRICS TABLE
+   ====================== */
+export const ridershipMetrics = pgTable("ridership_metrics", {
+  id: serial("id").primaryKey(),
+  reportingMonth: date("reporting_month").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+});

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,94 +1,94 @@
 // src/db/schema/index.ts
 
 import {
-    integer,
-    pgTable,
-    primaryKey,
-    text,
-    timestamp,
-    numeric,
-    date,
-    serial,
-  } from "drizzle-orm/pg-core";
-  
-  /* ======================
+  date,
+  integer,
+  numeric,
+  pgTable,
+  primaryKey,
+  serial,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
+
+/* ======================
      USERS TABLE
      ====================== */
-  export const users = pgTable("user", {
-    id: text("id")
-      .primaryKey()
-      .$defaultFn(() => crypto.randomUUID()),
-    name: text("name"),
-    email: text("email").unique(),
-    emailVerified: timestamp("emailVerified", { mode: "date" }),
-    image: text("image"),
-  });
-  
-  /* ======================
+export const users = pgTable("user", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  name: text("name"),
+  email: text("email").unique(),
+  emailVerified: timestamp("emailVerified", { mode: "date" }),
+  image: text("image"),
+});
+
+/* ======================
      ACCOUNTS TABLE
      ====================== */
-  export const accounts = pgTable(
-    "account",
-    {
-      userId: text("userId")
-        .notNull()
-        .references(() => users.id, { onDelete: "cascade" }),
-      type: text("type").notNull(),
-      provider: text("provider").notNull(),
-      providerAccountId: text("providerAccountId").notNull(),
-      refresh_token: text("refresh_token"),
-      access_token: text("access_token"),
-      expires_at: integer("expires_at"),
-      token_type: text("token_type"),
-      scope: text("scope"),
-      id_token: text("id_token"),
-      session_state: text("session_state"),
-    },
-    (account) => [
-      {
-        compoundKey: primaryKey({
-          columns: [account.provider, account.providerAccountId],
-        }),
-      },
-    ],
-  );
-  
-  /* ======================
-     SESSIONS TABLE
-     ====================== */
-  export const sessions = pgTable("session", {
-    sessionToken: text("sessionToken").primaryKey(),
+export const accounts = pgTable(
+  "account",
+  {
     userId: text("userId")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
-    expires: timestamp("expires", { mode: "date" }).notNull(),
-  });
-  
-  /* ======================
+    type: text("type").notNull(),
+    provider: text("provider").notNull(),
+    providerAccountId: text("providerAccountId").notNull(),
+    refresh_token: text("refresh_token"),
+    access_token: text("access_token"),
+    expires_at: integer("expires_at"),
+    token_type: text("token_type"),
+    scope: text("scope"),
+    id_token: text("id_token"),
+    session_state: text("session_state"),
+  },
+  (account) => [
+    {
+      compoundKey: primaryKey({
+        columns: [account.provider, account.providerAccountId],
+      }),
+    },
+  ],
+);
+
+/* ======================
+     SESSIONS TABLE
+     ====================== */
+export const sessions = pgTable("session", {
+  sessionToken: text("sessionToken").primaryKey(),
+  userId: text("userId")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  expires: timestamp("expires", { mode: "date" }).notNull(),
+});
+
+/* ======================
      CHARTER EVENTS TABLE
      ====================== */
-  export const charterEvents = pgTable("charter_events", {
-    id: serial("id").primaryKey(),
-  
-    reportingMonth: date("reporting_month").notNull(),
-    eventType: text("event_type").notNull(),
-    eventDate: date("event_date"),
-  
-    passengerCount: integer("passenger_count"),
-    vehicleHours: numeric("vehicle_hours"),
-    vehicleMiles: numeric("vehicle_miles"),
-  
-    driverAssignments: text("driver_assignments"),
-  
-    revenueTotal: numeric("revenue_total"),
-    serviceTotal: numeric("service_total"),
-  
-    createdAt: timestamp("created_at", { withTimezone: true })
-      .defaultNow()
-      .notNull(),
-  });
-  
-  /* ======================
+export const charterEvents = pgTable("charter_events", {
+  id: serial("id").primaryKey(),
+
+  reportingMonth: date("reporting_month").notNull(),
+  eventType: text("event_type").notNull(),
+  eventDate: date("event_date"),
+
+  passengerCount: integer("passenger_count"),
+  vehicleHours: numeric("vehicle_hours"),
+  vehicleMiles: numeric("vehicle_miles"),
+
+  driverAssignments: text("driver_assignments"),
+
+  revenueTotal: numeric("revenue_total"),
+  serviceTotal: numeric("service_total"),
+
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+});
+
+/* ======================
    RIDERSHIP METRICS TABLE
    ====================== */
 export const ridershipMetrics = pgTable("ridership_metrics", {


### PR DESCRIPTION
## Description
Connects the **Ridership and System Performance** page to a new `/api/ridership` endpoint and the `ridership_metrics` table, following the existing **Charters** implementation pattern. Adds a monthly reporting date picker, save functionality, and a list of saved entries.

## Relevant Issues
- Connect Ridership Page to Database API (#35 )

## How to Test
1. Set `DATABASE_URL` in `.env.local`.
2. Run database migrations:
   ```bash
   pnpm drizzle-kit migrate