### PR TITLE
feat: expand maintenance metrics to match diagram fields

### DIFF
--- a/src/app/api/maintenance/route.ts
+++ b/src/app/api/maintenance/route.ts
@@ -1,34 +1,59 @@
 import { NextRequest, NextResponse } from "next/server";
 import db from "@/db";
 import { maintenanceMetrics } from "@/db/schema";
+import { eq, asc } from "drizzle-orm";
 
 type MaintenanceMetricsPayload = {
-  reportingMonth: string | null; // ISO string from client
-  motorBusMajor?: number | null;
-  motorBusOther?: number | null;
-  liftMajor?: number | null;
-  liftOther?: number | null;
-  interruptions?: number | null;
-  diesel?: number | null;
-  cng?: number | null;
-  electric?: number | null;
+  monthlyReportId: number;
+  motorBusMajorRoadCalls?: number | null;
+  motorBusOtherRoadCalls?: number | null;
+  liftMajorRoadCalls?: number | null;
+  liftOtherRoadCalls?: number | null;
+  busDieselGallons?: number | null;
+  busGasolineGallons?: number | null;
+  ebKwhCharging?: number | null;
+  ebKwhPropulsion?: number | null;
+  liftDieselGallons?: number | null;
+  liftGasolineGallons?: number | null;
 };
 
 export async function POST(req: NextRequest) {
   try {
     const body = (await req.json()) as MaintenanceMetricsPayload;
 
-    const { reportingMonth } = body;
+    const { monthlyReportId } = body;
 
-    if (!reportingMonth) {
+    if (!monthlyReportId) {
       return NextResponse.json(
-        { error: "reportingMonth is required" },
+        { error: "monthlyReportId is required" },
         { status: 400 },
       );
     }
 
+    const existing = await db
+      .select()
+      .from(maintenanceMetrics)
+      .where(eq(maintenanceMetrics.monthlyReportId, monthlyReportId))
+      .limit(1);
+
+    if (existing.length > 0) {
+      await db
+        .delete(maintenanceMetrics)
+        .where(eq(maintenanceMetrics.monthlyReportId, monthlyReportId));
+    }
+
     await db.insert(maintenanceMetrics).values({
-      reportingMonth,
+      monthlyReportId,
+      motorBusMajorRoadCalls: body.motorBusMajorRoadCalls ?? 0,
+      motorBusOtherRoadCalls: body.motorBusOtherRoadCalls ?? 0,
+      liftMajorRoadCalls: body.liftMajorRoadCalls ?? 0,
+      liftOtherRoadCalls: body.liftOtherRoadCalls ?? 0,
+      busDieselGallons: body.busDieselGallons ?? 0,
+      busGasolineGallons: body.busGasolineGallons ?? 0,
+      ebKwhCharging: body.ebKwhCharging ?? 0,
+      ebKwhPropulsion: body.ebKwhPropulsion ?? 0,
+      liftDieselGallons: body.liftDieselGallons ?? 0,
+      liftGasolineGallons: body.liftGasolineGallons ?? 0,
     });
 
     return NextResponse.json({ ok: true });
@@ -41,12 +66,25 @@ export async function POST(req: NextRequest) {
   }
 }
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   try {
+    const monthlyReportIdParam = req.nextUrl.searchParams.get("monthlyReportId");
+
+    if (monthlyReportIdParam) {
+      const monthlyReportId = Number(monthlyReportIdParam);
+
+      const rows = await db
+        .select()
+        .from(maintenanceMetrics)
+        .where(eq(maintenanceMetrics.monthlyReportId, monthlyReportId));
+
+      return NextResponse.json(rows);
+    }
+
     const rows = await db
       .select()
       .from(maintenanceMetrics)
-      .orderBy(maintenanceMetrics.id);
+      .orderBy(asc(maintenanceMetrics.id));
 
     return NextResponse.json(rows);
   } catch (err) {

--- a/src/app/departments/maintenance/page.tsx
+++ b/src/app/departments/maintenance/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import {
   Box,
   TextField,
@@ -21,14 +21,16 @@ export default function Maintenance() {
     dayjs()
   );
   const [values, setValues] = useState({
-    motorBusMajor: "",
-    motorBusOther: "",
-    liftMajor: "",
-    liftOther: "",
-    interruptions: "",
-    diesel: "",
-    cng: "",
-    electric: "",
+    motorBusMajorRoadCalls: "",
+    motorBusOtherRoadCalls: "",
+    liftMajorRoadCalls: "",
+    liftOtherRoadCalls: "",
+    busDieselGallons: "",
+    busGasolineGallons: "",
+    ebKwhCharging: "",
+    ebKwhPropulsion: "",
+    liftDieselGallons: "",
+    liftGasolineGallons: "",
   });
 
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -41,6 +43,8 @@ export default function Maintenance() {
     }
   };
 
+  const toInt = (v: string) => (v ? parseInt(v, 10) : 0);
+
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setSubmitError(null);
@@ -51,6 +55,9 @@ export default function Maintenance() {
       return;
     }
 
+    const monthlyReportId =
+      reportingMonth.year() * 100 + (reportingMonth.month() + 1);
+
     setIsSubmitting(true);
 
     try {
@@ -58,25 +65,17 @@ export default function Maintenance() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          reportingMonth: reportingMonth.toISOString(),
-          motorBusMajor: values.motorBusMajor
-            ? parseInt(values.motorBusMajor, 10)
-            : null,
-          motorBusOther: values.motorBusOther
-            ? parseInt(values.motorBusOther, 10)
-            : null,
-          liftMajor: values.liftMajor
-            ? parseInt(values.liftMajor, 10)
-            : null,
-          liftOther: values.liftOther
-            ? parseInt(values.liftOther, 10)
-            : null,
-          interruptions: values.interruptions
-            ? parseInt(values.interruptions, 10)
-            : null,
-          diesel: values.diesel ? parseInt(values.diesel, 10) : null,
-          cng: values.cng ? parseInt(values.cng, 10) : null,
-          electric: values.electric ? parseInt(values.electric, 10) : null,
+          monthlyReportId,
+          motorBusMajorRoadCalls: toInt(values.motorBusMajorRoadCalls),
+          motorBusOtherRoadCalls: toInt(values.motorBusOtherRoadCalls),
+          liftMajorRoadCalls: toInt(values.liftMajorRoadCalls),
+          liftOtherRoadCalls: toInt(values.liftOtherRoadCalls),
+          busDieselGallons: toInt(values.busDieselGallons),
+          busGasolineGallons: toInt(values.busGasolineGallons),
+          ebKwhCharging: toInt(values.ebKwhCharging),
+          ebKwhPropulsion: toInt(values.ebKwhPropulsion),
+          liftDieselGallons: toInt(values.liftDieselGallons),
+          liftGasolineGallons: toInt(values.liftGasolineGallons),
         }),
       });
 
@@ -87,18 +86,19 @@ export default function Maintenance() {
 
       setSubmitSuccess(true);
       setValues({
-        motorBusMajor: "",
-        motorBusOther: "",
-        liftMajor: "",
-        liftOther: "",
-        interruptions: "",
-        diesel: "",
-        cng: "",
-        electric: "",
+        motorBusMajorRoadCalls: "",
+        motorBusOtherRoadCalls: "",
+        liftMajorRoadCalls: "",
+        liftOtherRoadCalls: "",
+        busDieselGallons: "",
+        busGasolineGallons: "",
+        ebKwhCharging: "",
+        ebKwhPropulsion: "",
+        liftDieselGallons: "",
+        liftGasolineGallons: "",
       });
       setReportingMonth(dayjs());
 
-      // Clear success message after 3 seconds
       setTimeout(() => setSubmitSuccess(false), 3000);
     } catch (err) {
       const errorMessage =
@@ -144,7 +144,6 @@ export default function Maintenance() {
 
             <form onSubmit={handleSubmit}>
               <Stack spacing={3}>
-                {/* Reporting Month */}
                 <Box maxWidth={400}>
                   <DatePicker
                     views={["year", "month"]}
@@ -159,7 +158,6 @@ export default function Maintenance() {
                   />
                 </Box>
 
-                {/* Road Calls Section */}
                 <Box>
                   <Typography variant="h6" gutterBottom>
                     Road Calls
@@ -168,88 +166,120 @@ export default function Maintenance() {
                     <TextField
                       label="Motor Bus — Major"
                       type="number"
-                      value={values.motorBusMajor}
+                      value={values.motorBusMajorRoadCalls}
                       onChange={(e) =>
-                        handleChange("motorBusMajor", e.target.value)
+                        handleChange("motorBusMajorRoadCalls", e.target.value)
                       }
                       inputProps={{ min: 0 }}
                     />
                     <TextField
                       label="Motor Bus — Other"
                       type="number"
-                      value={values.motorBusOther}
+                      value={values.motorBusOtherRoadCalls}
                       onChange={(e) =>
-                        handleChange("motorBusOther", e.target.value)
+                        handleChange("motorBusOtherRoadCalls", e.target.value)
                       }
                       inputProps={{ min: 0 }}
                     />
                     <TextField
                       label="Lift — Major"
                       type="number"
-                      value={values.liftMajor}
-                      onChange={(e) => handleChange("liftMajor", e.target.value)}
+                      value={values.liftMajorRoadCalls}
+                      onChange={(e) =>
+                        handleChange("liftMajorRoadCalls", e.target.value)
+                      }
                       inputProps={{ min: 0 }}
                     />
                     <TextField
                       label="Lift — Other"
                       type="number"
-                      value={values.liftOther}
-                      onChange={(e) => handleChange("liftOther", e.target.value)}
-                      inputProps={{ min: 0 }}
-                    />
-                  </Box>
-                </Box>
-
-                {/* Service Interruptions */}
-                <Box>
-                  <Typography variant="h6" gutterBottom>
-                    Service Interruptions
-                  </Typography>
-                  <Box maxWidth={300}>
-                    <TextField
-                      label="Service Interruptions"
-                      type="number"
-                      value={values.interruptions}
+                      value={values.liftOtherRoadCalls}
                       onChange={(e) =>
-                        handleChange("interruptions", e.target.value)
+                        handleChange("liftOtherRoadCalls", e.target.value)
                       }
                       inputProps={{ min: 0 }}
-                      fullWidth
                     />
                   </Box>
                 </Box>
 
-                {/* Fuel / Energy Consumption */}
                 <Box>
                   <Typography variant="h6" gutterBottom>
-                    Fuel / Energy Consumption
+                    Bus Fuel
                   </Typography>
                   <Box display="flex" flexWrap="wrap" gap={2}>
                     <TextField
-                      label="Diesel (gal)"
+                      label="Bus Diesel (gal)"
                       type="number"
-                      value={values.diesel}
-                      onChange={(e) => handleChange("diesel", e.target.value)}
+                      value={values.busDieselGallons}
+                      onChange={(e) =>
+                        handleChange("busDieselGallons", e.target.value)
+                      }
                       inputProps={{ min: 0 }}
                     />
                     <TextField
-                      label="CNG (GGE)"
+                      label="Bus Gasoline (gal)"
                       type="number"
-                      value={values.cng}
-                      onChange={(e) => handleChange("cng", e.target.value)}
-                      inputProps={{ min: 0 }}
-                    />
-                    <TextField
-                      label="Electric (kWh)"
-                      type="number"
-                      value={values.electric}
-                      onChange={(e) => handleChange("electric", e.target.value)}
+                      value={values.busGasolineGallons}
+                      onChange={(e) =>
+                        handleChange("busGasolineGallons", e.target.value)
+                      }
                       inputProps={{ min: 0 }}
                     />
                   </Box>
                 </Box>
 
-                {/* Save Button */}
+                <Box>
+                  <Typography variant="h6" gutterBottom>
+                    Electric Bus Energy
+                  </Typography>
+                  <Box display="flex" flexWrap="wrap" gap={2}>
+                    <TextField
+                      label="EB kWh — Charging"
+                      type="number"
+                      value={values.ebKwhCharging}
+                      onChange={(e) =>
+                        handleChange("ebKwhCharging", e.target.value)
+                      }
+                      inputProps={{ min: 0 }}
+                    />
+                    <TextField
+                      label="EB kWh — Propulsion"
+                      type="number"
+                      value={values.ebKwhPropulsion}
+                      onChange={(e) =>
+                        handleChange("ebKwhPropulsion", e.target.value)
+                      }
+                      inputProps={{ min: 0 }}
+                    />
+                  </Box>
+                </Box>
+
+                <Box>
+                  <Typography variant="h6" gutterBottom>
+                    Lift Fuel
+                  </Typography>
+                  <Box display="flex" flexWrap="wrap" gap={2}>
+                    <TextField
+                      label="Lift Diesel (gal)"
+                      type="number"
+                      value={values.liftDieselGallons}
+                      onChange={(e) =>
+                        handleChange("liftDieselGallons", e.target.value)
+                      }
+                      inputProps={{ min: 0 }}
+                    />
+                    <TextField
+                      label="Lift Gasoline (gal)"
+                      type="number"
+                      value={values.liftGasolineGallons}
+                      onChange={(e) =>
+                        handleChange("liftGasolineGallons", e.target.value)
+                      }
+                      inputProps={{ min: 0 }}
+                    />
+                  </Box>
+                </Box>
+
                 <Box>
                   <Button
                     type="submit"
@@ -275,4 +305,3 @@ export default function Maintenance() {
     </main>
   );
 }
-

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -119,7 +119,19 @@ import {
   export const maintenanceMetrics = pgTable("maintenance_metrics", {
     id: serial("id").primaryKey(),
 
-    reportingMonth: date("reporting_month").notNull(),
+    monthlyReportId: integer("monthly_report_id").notNull(),
+
+    motorBusMajorRoadCalls: integer("motor_bus_major_road_calls").default(0),
+    motorBusOtherRoadCalls: integer("motor_bus_other_road_calls").default(0),
+    liftMajorRoadCalls: integer("lift_major_road_calls").default(0),
+    liftOtherRoadCalls: integer("lift_other_road_calls").default(0),
+
+    busDieselGallons: integer("bus_diesel_gallons").default(0),
+    busGasolineGallons: integer("bus_gasoline_gallons").default(0),
+    ebKwhCharging: integer("eb_kwh_charging").default(0),
+    ebKwhPropulsion: integer("eb_kwh_propulsion").default(0),
+    liftDieselGallons: integer("lift_diesel_gallons").default(0),
+    liftGasolineGallons: integer("lift_gasoline_gallons").default(0),
 
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()


### PR DESCRIPTION
Rework maintenance metrics so it actually stores the road-call and fuel/energy data from the diagram instead of just a date.