### PR TITLE
feat: add FixedRouteLineSummary table and import flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-hook-form": "^7.62.0",
     "react-router-dom": "^7.9.4",
     "recharts": "^3.3.0",
+    "xlsx": "^0.18.5",
     "zod": "^4.0.17"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,13 +37,19 @@ importers:
         version: 8.10.0(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@mui/system@7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@mui/x-date-pickers':
         specifier: ^8.16.0
-        version: 8.16.0(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@mui/system@7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(date-fns@4.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 8.16.0(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@mui/system@7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(date-fns@4.1.0)(dayjs@1.11.20)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@neondatabase/serverless':
         specifier: ^1.0.1
         version: 1.0.1
+      chart.js:
+        specifier: ^4.5.1
+        version: 4.5.1
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      dayjs:
+        specifier: ^1.11.19
+        version: 1.11.20
       dotenv:
         specifier: ^17.2.1
         version: 17.2.1
@@ -63,7 +69,7 @@ importers:
         specifier: ^10.19.0
         version: 10.20.0
       react:
-        specifier: 19.1.0
+        specifier: ^19.1.0
         version: 19.1.0
       react-dom:
         specifier: 19.1.0
@@ -77,6 +83,9 @@ importers:
       recharts:
         specifier: ^3.3.0
         version: 3.3.0(@types/react@19.1.9)(react-dom@19.1.0(react@19.1.0))(react-is@19.1.1)(react@19.1.0)(redux@5.0.1)
+      xlsx:
+        specifier: ^0.18.5
+        version: 0.18.5
       zod:
         specifier: ^4.0.17
         version: 4.0.17
@@ -770,6 +779,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.29':
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
 
+  '@kurkle/color@0.3.4':
+    resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
+
   '@mui/core-downloads-tracker@7.3.1':
     resolution: {integrity: sha512-+mIK1Z0BhOaQ0vCgOkT1mSrIpEHLo338h4/duuL4TBLXPvUMit732mnwJY3W40Avy30HdeSfwUAAGRkKmwRaEQ==}
 
@@ -1414,6 +1426,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -1531,12 +1547,20 @@ packages:
   caniuse-lite@1.0.30001733:
     resolution: {integrity: sha512-e4QKw/O2Kavj2VQTKZWrwzkt3IxOmIlU6ajRb6LP64LHpBo1J67k2Hi4Vu/TgJWsNtynurfS0uK3MaUTCPfu5Q==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
+  chart.js@4.5.1:
+    resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
+    engines: {pnpm: '>=8'}
 
   ci-info@4.3.0:
     resolution: {integrity: sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==}
@@ -1560,6 +1584,10 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1600,6 +1628,11 @@ packages:
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1669,6 +1702,9 @@ packages:
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -2108,6 +2144,10 @@ packages:
     resolution: {integrity: sha512-lIN7GpcvX/l/i24r/L9bnJ0I8Qn01qijWpQpDDvTLL29nKqSaJJu4h20+7VJ6m2CAhQ2/En/GbxDiHCzq/0MyA==}
     engines: {node: '>=18.3.0'}
     hasBin: true
+
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -2942,6 +2982,10 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
@@ -3153,13 +3197,26 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -3693,6 +3750,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
 
+  '@kurkle/color@0.3.4': {}
+
   '@mui/core-downloads-tracker@7.3.1': {}
 
   '@mui/icons-material@7.3.1(@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.9)(react@19.1.0)':
@@ -3827,7 +3886,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-date-pickers@8.16.0(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@mui/system@7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(date-fns@4.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@mui/x-date-pickers@8.16.0(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@mui/system@7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(date-fns@4.1.0)(dayjs@1.11.20)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@mui/material': 7.3.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -3844,6 +3903,7 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@19.1.9)(react@19.1.0)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.0))(@types/react@19.1.9)(react@19.1.0)
       date-fns: 4.1.0
+      dayjs: 1.11.20
     transitivePeerDependencies:
       - '@types/react'
 
@@ -4254,6 +4314,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  adler-32@1.3.1: {}
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4403,12 +4465,21 @@ snapshots:
 
   caniuse-lite@1.0.30001733: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
   change-case@5.4.4: {}
+
+  chart.js@4.5.1:
+    dependencies:
+      '@kurkle/color': 0.3.4
 
   ci-info@4.3.0: {}
 
@@ -4427,6 +4498,8 @@ snapshots:
   clsx@1.2.1: {}
 
   clsx@2.1.1: {}
+
+  codepage@1.15.0: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -4475,6 +4548,8 @@ snapshots:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.2
+
+  crc-32@1.2.2: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4543,6 +4618,8 @@ snapshots:
       is-data-view: 1.0.2
 
   date-fns@4.1.0: {}
+
+  dayjs@1.11.20: {}
 
   debug@3.2.7:
     dependencies:
@@ -5087,6 +5164,8 @@ snapshots:
   formatly@0.2.4:
     dependencies:
       fd-package-json: 2.0.0
+
+  frac@1.1.2: {}
 
   fsevents@2.3.3:
     optional: true
@@ -5965,6 +6044,10 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   stable-hash@0.0.5: {}
 
   stop-iteration-iterator@1.1.0:
@@ -6263,13 +6346,27 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  wmf@1.0.2: {}
+
   word-wrap@1.2.5: {}
+
+  word@0.3.0: {}
 
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
 
   xtend@4.0.2: {}
 

--- a/src/app/api/line-summary/route.ts
+++ b/src/app/api/line-summary/route.ts
@@ -1,0 +1,92 @@
+// src/app/api/line-summary/route.ts
+import db from "@/db";
+import { fixedRouteLineSummary, NewFixedRouteLineSummary } from "@/db/schema";
+import handleError from "@/utils/handle-error";
+import { eq } from "drizzle-orm";
+import { NextRequest, NextResponse } from "next/server";
+
+// ── GET /api/line-summary?monthlyReportId=<id> ────────────────────────────────
+// Returns all line summary rows for a given monthly report, optionally filtered
+// by day type.  Joins naturally with fixed_route_monthly_ridership on
+// (monthly_report_id, route_number, day_type).
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const monthlyReportIdParam = searchParams.get("monthlyReportId");
+
+    if (!monthlyReportIdParam) {
+      return NextResponse.json(
+        { error: "monthlyReportId query param is required" },
+        { status: 400 }
+      );
+    }
+
+    const monthlyReportId = parseInt(monthlyReportIdParam, 10);
+    if (isNaN(monthlyReportId)) {
+      return NextResponse.json(
+        { error: "monthlyReportId must be an integer" },
+        { status: 400 }
+      );
+    }
+
+    const rows = await db
+      .select()
+      .from(fixedRouteLineSummary)
+      .where(eq(fixedRouteLineSummary.monthlyReportId, monthlyReportId));
+
+    return NextResponse.json(rows);
+  } catch (err) {
+    return handleError(err);
+  }
+}
+
+// ── POST /api/line-summary ────────────────────────────────────────────────────
+// Bulk-inserts line summary rows for a monthly report.
+// Body: { monthlyReportId: number; rows: NewFixedRouteLineSummary[] }
+//
+// Idempotency: existing rows for (monthlyReportId) are deleted first so
+// re-importing a corrected file is safe.
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { monthlyReportId, rows } = body as {
+      monthlyReportId: number;
+      rows: NewFixedRouteLineSummary[];
+    };
+
+    if (!monthlyReportId || !Array.isArray(rows) || rows.length === 0) {
+      return NextResponse.json(
+        { error: "monthlyReportId and a non-empty rows array are required" },
+        { status: 400 }
+      );
+    }
+
+    // Validate day_type values before hitting the DB
+    const validDayTypes = new Set(["weekday", "saturday", "sunday"]);
+    const invalid = rows.find(
+      (r) => r.dayType && !validDayTypes.has(r.dayType)
+    );
+    if (invalid) {
+      return NextResponse.json(
+        {
+          error: `Invalid day_type "${invalid.dayType}". Must be weekday | saturday | sunday.`,
+        },
+        { status: 422 }
+      );
+    }
+
+    await db.transaction(async (tx) => {
+    await tx
+        .delete(fixedRouteLineSummary)
+        .where(eq(fixedRouteLineSummary.monthlyReportId, monthlyReportId));
+
+    await tx
+        .insert(fixedRouteLineSummary)
+        .values(rows.map((r) => ({ ...r, monthlyReportId })));
+    });
+
+    return NextResponse.json({ inserted: rows.length }, { status: 201 });
+  } catch (err) {
+    return handleError(err);
+  }
+}

--- a/src/app/departments/ridership/line-summary/page.tsx
+++ b/src/app/departments/ridership/line-summary/page.tsx
@@ -1,0 +1,322 @@
+// src/app/departments/ridership/line-summary/page.tsx
+"use client";
+
+import React, { useCallback, useState } from "react";
+import * as XLSX from "xlsx";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type DayType = "weekday" | "saturday" | "sunday";
+
+interface LineSummaryRow {
+  routeNumber: number | null;
+  dayType: DayType;
+  peakVehicles: number | null;
+  revenueTimeHours: string | null;
+  nonRevenueTimeHours: string | null;
+  recoveryTimeHours: string | null;
+  revenueDistanceMiles: string | null;
+  nonRevenueDistanceMiles: string | null;
+  revenueTrips: number | null;
+  nonRevenueTrips: number | null;
+  totalTimeHours: string | null;
+  totalDistanceMiles: string | null;
+}
+
+// ── Excel column mapping ──────────────────────────────────────────────────────
+// Adjust these indices to match the actual column layout in the xlsx sheets.
+const COL = {
+  routeNumber: 0,
+  peakVehicles: 1,
+  revenueTimeHours: 2,
+  nonRevenueTimeHours: 3,
+  recoveryTimeHours: 4,
+  revenueDistanceMiles: 5,
+  nonRevenueDistanceMiles: 6,
+  revenueTrips: 7,
+  nonRevenueTrips: 8,
+  totalTimeHours: 9,
+  totalDistanceMiles: 10,
+} as const;
+
+const SHEET_DAY_TYPE: Record<string, DayType> = {
+  Weekday: "weekday",
+  Saturday: "saturday",
+  Sunday: "sunday",
+};
+
+// ── Parsing helpers ───────────────────────────────────────────────────────────
+
+function toNum(v: unknown): number | null {
+  if (v === null || v === undefined || v === "") return null;
+  const n = Number(v);
+  return isNaN(n) ? null : n;
+}
+
+function toStr(v: unknown): string | null {
+  if (v === null || v === undefined || v === "") return null;
+  const n = Number(v);
+  return isNaN(n) ? null : String(n);
+}
+
+function isDataRow(row: unknown[]): boolean {
+  // A data row must have a numeric value in the route-number column
+  return toNum(row[COL.routeNumber]) !== null;
+}
+
+function parseSheet(
+  worksheet: XLSX.WorkSheet,
+  dayType: DayType,
+): LineSummaryRow[] {
+  const raw: unknown[][] = XLSX.utils.sheet_to_json(worksheet, {
+    header: 1,
+    defval: "",
+  });
+
+  return raw.filter(isDataRow).map((row) => ({
+    routeNumber: toNum(row[COL.routeNumber]),
+    dayType,
+    peakVehicles: toNum(row[COL.peakVehicles]),
+    revenueTimeHours: toStr(row[COL.revenueTimeHours]),
+    nonRevenueTimeHours: toStr(row[COL.nonRevenueTimeHours]),
+    recoveryTimeHours: toStr(row[COL.recoveryTimeHours]),
+    revenueDistanceMiles: toStr(row[COL.revenueDistanceMiles]),
+    nonRevenueDistanceMiles: toStr(row[COL.nonRevenueDistanceMiles]),
+    revenueTrips: toNum(row[COL.revenueTrips]),
+    nonRevenueTrips: toNum(row[COL.nonRevenueTrips]),
+    totalTimeHours: toStr(row[COL.totalTimeHours]),
+    totalDistanceMiles: toStr(row[COL.totalDistanceMiles]),
+  }));
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export default function LineSummaryPage() {
+  const [rows, setRows] = useState<LineSummaryRow[]>([]);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // monthlyReportId should come from route params or a context in the real app.
+  // Hardcoded here as a placeholder — wire up to your report-selection flow.
+  const monthlyReportId = 1;
+
+  const handleFile = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setFileName(file.name);
+    setSaved(false);
+    setError(null);
+
+    const reader = new FileReader();
+    reader.onload = (evt) => {
+      try {
+        const data = new Uint8Array(evt.target!.result as ArrayBuffer);
+        const workbook = XLSX.read(data, { type: "array" });
+
+        const parsed: LineSummaryRow[] = [];
+
+        for (const [sheetName, dayType] of Object.entries(SHEET_DAY_TYPE)) {
+          if (workbook.SheetNames.includes(sheetName)) {
+            parsed.push(...parseSheet(workbook.Sheets[sheetName], dayType));
+          }
+        }
+
+        if (parsed.length === 0) {
+          setError(
+            "No data rows found. Make sure the file has Weekday, Saturday, and/or Sunday sheets.",
+          );
+          return;
+        }
+
+        setRows(parsed);
+      } catch {
+        setError("Failed to parse the Excel file. Please check the format.");
+      }
+    };
+    reader.readAsArrayBuffer(file);
+  }, []);
+
+  const handleSave = async () => {
+    if (rows.length === 0) return;
+    setSaving(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/line-summary", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ monthlyReportId, rows }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? `Server error ${res.status}`);
+      }
+
+      setSaved(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const dayTypes: DayType[] = ["weekday", "saturday", "sunday"];
+
+  return (
+    <main style={{ padding: "2rem", fontFamily: "sans-serif" }}>
+      <h1>Monthly Line Summary Import</h1>
+      <p style={{ color: "#555" }}>
+        Upload the Monthly Line Summary Report Excel file. Weekday, Saturday,
+        and Sunday sheets will be parsed automatically.
+      </p>
+
+      {/* File input */}
+      <div style={{ margin: "1.5rem 0" }}>
+        <input
+          type="file"
+          accept=".xlsx,.xls"
+          onChange={handleFile}
+          style={{ display: "block", marginBottom: "0.5rem" }}
+        />
+        {fileName && (
+          <span style={{ fontSize: "0.875rem", color: "#444" }}>
+            Loaded: {fileName}
+          </span>
+        )}
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div
+          style={{
+            background: "#fee2e2",
+            border: "1px solid #f87171",
+            borderRadius: 6,
+            padding: "0.75rem 1rem",
+            marginBottom: "1rem",
+            color: "#b91c1c",
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {/* Preview tables, one per day type */}
+      {rows.length > 0 && (
+        <>
+          <p style={{ marginBottom: "0.5rem" }}>
+            <strong>{rows.length}</strong> rows parsed across{" "}
+            {dayTypes.filter((d) => rows.some((r) => r.dayType === d)).length}{" "}
+            day type(s).
+          </p>
+
+          {dayTypes.map((dt) => {
+            const subset = rows.filter((r) => r.dayType === dt);
+            if (subset.length === 0) return null;
+            return (
+              <section key={dt} style={{ marginBottom: "2rem" }}>
+                <h2 style={{ textTransform: "capitalize" }}>{dt}</h2>
+                <div style={{ overflowX: "auto" }}>
+                  <table
+                    style={{
+                      borderCollapse: "collapse",
+                      width: "100%",
+                      fontSize: "0.8rem",
+                    }}
+                  >
+                    <thead>
+                      <tr style={{ background: "#f1f5f9" }}>
+                        {[
+                          "Route",
+                          "Peak Veh.",
+                          "Rev. Time (h)",
+                          "Non-Rev. Time (h)",
+                          "Recovery (h)",
+                          "Rev. Miles",
+                          "Non-Rev. Miles",
+                          "Rev. Trips",
+                          "Non-Rev. Trips",
+                          "Total Time (h)",
+                          "Total Miles",
+                        ].map((h) => (
+                          <th
+                            key={h}
+                            style={{
+                              border: "1px solid #cbd5e1",
+                              padding: "6px 10px",
+                              textAlign: "right",
+                              whiteSpace: "nowrap",
+                            }}
+                          >
+                            {h}
+                          </th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {subset.map((r, i) => (
+                        <tr
+                          key={i}
+                          style={{
+                            background: i % 2 === 0 ? "#fff" : "#f8fafc",
+                          }}
+                        >
+                          {[
+                            r.routeNumber,
+                            r.peakVehicles,
+                            r.revenueTimeHours,
+                            r.nonRevenueTimeHours,
+                            r.recoveryTimeHours,
+                            r.revenueDistanceMiles,
+                            r.nonRevenueDistanceMiles,
+                            r.revenueTrips,
+                            r.nonRevenueTrips,
+                            r.totalTimeHours,
+                            r.totalDistanceMiles,
+                          ].map((val, j) => (
+                            <td
+                              key={j}
+                              style={{
+                                border: "1px solid #e2e8f0",
+                                padding: "5px 10px",
+                                textAlign: "right",
+                              }}
+                            >
+                              {val ?? "—"}
+                            </td>
+                          ))}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </section>
+            );
+          })}
+
+          {/* Save button */}
+          <button
+            onClick={handleSave}
+            disabled={saving || saved}
+            style={{
+              background: saved ? "#16a34a" : "#2563eb",
+              color: "#fff",
+              border: "none",
+              borderRadius: 6,
+              padding: "0.6rem 1.4rem",
+              fontSize: "1rem",
+              cursor: saving || saved ? "default" : "pointer",
+              opacity: saving ? 0.7 : 1,
+            }}
+          >
+            {saved ? "✓ Saved" : saving ? "Saving…" : "Save to Database"}
+          </button>
+        </>
+      )}
+    </main>
+  );
+}

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -214,3 +214,34 @@ import {
     monthlyRevenueMiles: integer("monthly_revenue_miles"),
     monthlyRevenueHours: numeric("monthly_revenue_hours"),
   });
+
+  /* ======================
+   FIXED ROUTE LINE SUMMARY TABLE
+   ====================== */
+export const fixedRouteLineSummary = pgTable("fixed_route_line_summary", {
+  id: serial("id").primaryKey(),
+
+  monthlyReportId: integer("monthly_report_id").notNull(),
+
+  routeNumber: integer("route_number"),
+
+  dayType: text("day_type"),
+
+  peakVehicles: integer("peak_vehicles"),
+
+  revenueTimeHours: numeric("revenue_time_hours"),
+  nonRevenueTimeHours: numeric("non_revenue_time_hours"),
+  recoveryTimeHours: numeric("recovery_time_hours"),
+
+  revenueDistanceMiles: numeric("revenue_distance_miles"),
+  nonRevenueDistanceMiles: numeric("non_revenue_distance_miles"),
+
+  revenueTrips: integer("revenue_trips"),
+  nonRevenueTrips: integer("non_revenue_trips"),
+
+  totalTimeHours: numeric("total_time_hours"),
+  totalDistanceMiles: numeric("total_distance_miles"),
+});
+
+export type FixedRouteLineSummary = typeof fixedRouteLineSummary.$inferSelect;
+export type NewFixedRouteLineSummary = typeof fixedRouteLineSummary.$inferInsert;


### PR DESCRIPTION
## Summary
Adds the fixed_route_line_summary table and supporting code per the issue spec.

## Changes
- Added `fixedRouteLineSummary` table to `src/db/schema/index.ts`
- Created `GET` and `POST` handlers at `src/app/api/line-summary/route.ts`
- Created upload/preview/save page at `src/app/departments/ridership/line-summary/page.tsx`
- Table created directly in the remote DB via SQL (migration history was out of sync with remote)

## Notes
- `monthlyReportId` in the page is hardcoded to 1, but needs to be wired to report-selection context
- Pre-existing TypeScript errors in charters/lift/ridership pages are unrelated to this PR