### PR TITLE
feat: NTD operational metrics table, API, and UI

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,6 +1,8 @@
-import "dotenv/config";
-
+import { config } from "dotenv";
 import { defineConfig } from "drizzle-kit";
+
+config({ path: ".env.local" });
+config({ path: ".env" });
 
 export default defineConfig({
   out: "./drizzle",

--- a/drizzle/0001_add_ntd_operational_metrics.sql
+++ b/drizzle/0001_add_ntd_operational_metrics.sql
@@ -1,0 +1,39 @@
+CREATE TABLE IF NOT EXISTS "monthly_department_report" (
+	"id" integer PRIMARY KEY NOT NULL,
+	"reporting_month" date NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "ntd_operational_metrics" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"monthly_report_id" integer NOT NULL,
+	"max_motor_buses_in_service" integer,
+	"max_lift_vehicles_in_service" integer,
+	"fixed_route_weekday_avg_riders" integer,
+	"fixed_route_weekday_avg_rev_hours" numeric,
+	"fixed_route_weekday_avg_rev_miles" numeric,
+	"fixed_route_sat_avg_riders" integer,
+	"fixed_route_sat_avg_rev_hours" numeric,
+	"fixed_route_sat_avg_rev_miles" numeric,
+	"fixed_route_sun_avg_riders" integer,
+	"fixed_route_sun_avg_rev_hours" numeric,
+	"fixed_route_sun_avg_rev_miles" numeric,
+	"demand_response_weekday_avg_riders" integer,
+	"demand_response_weekday_avg_rev_hours" numeric,
+	"demand_response_weekday_avg_rev_miles" numeric,
+	"demand_response_sat_avg_riders" integer,
+	"demand_response_sat_avg_rev_hours" numeric,
+	"demand_response_sat_avg_rev_miles" numeric,
+	"demand_response_sun_avg_riders" integer,
+	"demand_response_sun_avg_rev_hours" numeric,
+	"demand_response_sun_avg_rev_miles" numeric
+);
+--> statement-breakpoint
+ALTER TABLE "ntd_operational_metrics"
+ADD CONSTRAINT "ntd_operational_metrics_monthly_report_id_monthly_department_report_id_fk"
+FOREIGN KEY ("monthly_report_id") REFERENCES "public"."monthly_department_report"("id")
+ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ntd_operational_metrics_monthly_report_id_idx"
+ON "ntd_operational_metrics" ("monthly_report_id");
+

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1755048222201,
       "tag": "0000_dear_phalanx",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1776643200000,
+      "tag": "0001_add_ntd_operational_metrics",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,6 @@
       "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.34.2.tgz",
       "integrity": "sha512-KywHKRgLiF3l7PLyL73fjLSIBe1YNcA6sMeew4yMP6cfCWGXZrkkXd32AjRi1hlJ9nvovUBGZHvbn+LijO6ZeQ==",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@panva/hkdf": "^1.1.1",
         "@types/cookie": "0.6.0",
@@ -95,7 +94,6 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -105,20 +103,8 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
       "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
       "optional": true,
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/@auth/core/node_modules/preact": {
-      "version": "10.11.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
-      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/@auth/core/node_modules/preact-render-to-string": {
@@ -126,7 +112,6 @@
       "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.3.tgz",
       "integrity": "sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "pretty-format": "^3.8.0"
       },
@@ -380,6 +365,7 @@
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
       "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0",
         "@emotion/sheet": "^1.4.0",
@@ -410,6 +396,7 @@
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -450,6 +437,7 @@
       "version": "11.14.1",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1991,6 +1979,7 @@
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.4.tgz",
       "integrity": "sha512-gEQL9pbJZZHT7lYJBKQCS723v1MGys2IFc94COXbUIyCTWa+qC77a7hUax4Yjd5ggEm35dk4AyYABpKKWC4MLw==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/core-downloads-tracker": "^7.3.4",
@@ -2132,6 +2121,7 @@
       "version": "7.3.3",
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.3.tgz",
       "integrity": "sha512-Lqq3emZr5IzRLKaHPuMaLBDVaGvxoh6z7HMWd1RPKawBM5uMRaQ4ImsmmgXWtwJdfZux5eugfDhXJUo2mliS8Q==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/private-theming": "^7.3.3",
@@ -2935,8 +2925,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
@@ -3014,6 +3003,7 @@
       "version": "20.19.22",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.22.tgz",
       "integrity": "sha512-hRnu+5qggKDSyWHlnmThnUqg62l29Aj/6vcYgUaSFL9oc7DVjeWEQN3PRgdSc6F8d9QRMWkf36CLMch1Do/+RQ==",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3042,6 +3032,7 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3111,6 +3102,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.2.tgz",
       "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -3608,6 +3600,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3949,6 +3942,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -4270,7 +4264,8 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "peer": true
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -4444,6 +4439,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -4453,7 +4449,8 @@
       "version": "1.11.19",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
       "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -4914,6 +4911,7 @@
       "integrity": "sha512-KohQwyzrKTQmhXDW1PjCv3Tyspn9n5GcY2RTDqeORIdIJY8yKIF7sTSopFmn/wpMPW4rdPXI0UE5LJLuq3bx0Q==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4986,6 +4984,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5081,6 +5080,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5176,6 +5176,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6901,6 +6902,7 @@
       "version": "15.4.6",
       "resolved": "https://registry.npmjs.org/next/-/next-15.4.6.tgz",
       "integrity": "sha512-us++E/Q80/8+UekzB3SAGs71AlLDsadpFMXVNM/uQ0BMwsh9m3mr0UNQIfjKed8vpWXsASe+Qifrnu1oLIcKEQ==",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.4.6",
         "@swc/helpers": "0.5.15",
@@ -7024,7 +7026,6 @@
       "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-2.17.0.tgz",
       "integrity": "sha512-lbC0Z7uzAFNFyzEYRIC+pkSVvDHJTbEW+dYlSBAlCYDe6RxUkJ26bClhk8ocBZip1wfI9uKTe0fm4Ib4RHn6uQ==",
       "optional": true,
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -7364,6 +7365,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7470,6 +7472,7 @@
       "version": "10.24.3",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -7500,6 +7503,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7575,6 +7579,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7583,6 +7588,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -7594,6 +7600,7 @@
       "version": "7.65.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.65.0.tgz",
       "integrity": "sha512-xtOzDz063WcXvGWaHgLNrNzlsdFgtUWcb32E6WFaGTd7kPZG3EeDusjdZfUsPwKCKVXy1ZlntifaHZ4l8pAsmw==",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -7608,12 +7615,14 @@
     "node_modules/react-is": {
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
-      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA=="
+      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -7720,7 +7729,8 @@
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -8651,6 +8661,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/app/api/auth/[...nextauth]/auth-options.ts
+++ b/src/app/api/auth/[...nextauth]/auth-options.ts
@@ -5,7 +5,11 @@ import GoogleProvider from "next-auth/providers/google";
 import db from "@/db";
 
 const authOptions: NextAuthOptions = {
-  adapter: DrizzleAdapter(db),
+  ...(db
+    ? {
+        adapter: DrizzleAdapter(db),
+      }
+    : {}),
   providers: [
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID,

--- a/src/app/api/hr/route.ts
+++ b/src/app/api/hr/route.ts
@@ -9,7 +9,6 @@ type HrMetricsPayload = {
   otpSaturday: number | null;
   otpSunday: number | null;
   otpSystem: number | null;
-  peakVehicles: number | null;
   driverHours: number | null;
   overtimeHours: number | null;
   absenteeism: number | null;
@@ -21,6 +20,13 @@ const toNullableString = (value: number | null): string | null =>
 
 export async function POST(req: NextRequest) {
   try {
+    if (!db) {
+      return NextResponse.json(
+        { error: "DATABASE_URL is not set" },
+        { status: 500 },
+      );
+    }
+
     const body = (await req.json()) as HrMetricsPayload;
 
     if (!body.reportingMonth) {
@@ -36,7 +42,6 @@ export async function POST(req: NextRequest) {
       otpSaturday: toNullableString(body.otpSaturday),
       otpSunday: toNullableString(body.otpSunday),
       otpSystem: toNullableString(body.otpSystem),
-      peakVehicles: body.peakVehicles,
       driverHours: toNullableString(body.driverHours),
       overtimeHours: toNullableString(body.overtimeHours),
       absenteeism: toNullableString(body.absenteeism),
@@ -57,6 +62,13 @@ export async function POST(req: NextRequest) {
 
 export async function GET() {
   try {
+    if (!db) {
+      return NextResponse.json(
+        { error: "DATABASE_URL is not set" },
+        { status: 500 },
+      );
+    }
+
     const rows = await db.select().from(hrMetrics).orderBy(hrMetrics.id);
     return NextResponse.json(rows);
   } catch (error) {

--- a/src/app/api/ntd-operational/route.ts
+++ b/src/app/api/ntd-operational/route.ts
@@ -1,0 +1,178 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import db from "@/db";
+import { monthlyDepartmentReport, ntdOperationalMetrics } from "@/db/schema";
+import { eq } from "drizzle-orm";
+
+type NtdOperationalMetricsPayload = {
+  monthlyReportId: number | null;
+
+  maxMotorBusesInService: number | null;
+  maxLiftVehiclesInService: number | null;
+
+  fixedRouteWeekdayAvgRiders: number | null;
+  fixedRouteWeekdayAvgRevHours: number | null;
+  fixedRouteWeekdayAvgRevMiles: number | null;
+  fixedRouteSatAvgRiders: number | null;
+  fixedRouteSatAvgRevHours: number | null;
+  fixedRouteSatAvgRevMiles: number | null;
+  fixedRouteSunAvgRiders: number | null;
+  fixedRouteSunAvgRevHours: number | null;
+  fixedRouteSunAvgRevMiles: number | null;
+
+  demandResponseWeekdayAvgRiders: number | null;
+  demandResponseWeekdayAvgRevHours: number | null;
+  demandResponseWeekdayAvgRevMiles: number | null;
+  demandResponseSatAvgRiders: number | null;
+  demandResponseSatAvgRevHours: number | null;
+  demandResponseSatAvgRevMiles: number | null;
+  demandResponseSunAvgRiders: number | null;
+  demandResponseSunAvgRevHours: number | null;
+  demandResponseSunAvgRevMiles: number | null;
+};
+
+const toNullableString = (value: number | null): string | null =>
+  value === null ? null : String(value);
+
+function monthlyReportIdToIsoDate(monthlyReportId: number): string {
+  const year = Math.floor(monthlyReportId / 100);
+  const month = monthlyReportId % 100;
+  const safeMonth = Math.min(Math.max(month, 1), 12);
+  return `${year}-${String(safeMonth).padStart(2, "0")}-01`;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    if (!db) {
+      return NextResponse.json(
+        { error: "DATABASE_URL is not set" },
+        { status: 500 },
+      );
+    }
+
+    const body = (await req.json()) as NtdOperationalMetricsPayload;
+
+    if (!body.monthlyReportId) {
+      return NextResponse.json(
+        { error: "monthlyReportId is required" },
+        { status: 400 },
+      );
+    }
+
+    const monthlyReportId = body.monthlyReportId;
+
+    // Ensure the parent monthly report exists (dependency: MonthlyDepartmentReport)
+    const parent = await db
+      .select({ id: monthlyDepartmentReport.id })
+      .from(monthlyDepartmentReport)
+      .where(eq(monthlyDepartmentReport.id, monthlyReportId))
+      .limit(1);
+
+    if (parent.length === 0) {
+      await db.insert(monthlyDepartmentReport).values({
+        id: monthlyReportId,
+        reportingMonth: monthlyReportIdToIsoDate(monthlyReportId),
+      });
+    }
+
+    // Upsert-by-replace: 1 row per monthly report id
+    await db
+      .delete(ntdOperationalMetrics)
+      .where(eq(ntdOperationalMetrics.monthlyReportId, monthlyReportId));
+
+    const insertValues: typeof ntdOperationalMetrics.$inferInsert = {
+      monthlyReportId,
+
+      maxMotorBusesInService: body.maxMotorBusesInService,
+      maxLiftVehiclesInService: body.maxLiftVehiclesInService,
+
+      fixedRouteWeekdayAvgRiders: body.fixedRouteWeekdayAvgRiders,
+      fixedRouteWeekdayAvgRevHours: toNullableString(
+        body.fixedRouteWeekdayAvgRevHours,
+      ),
+      fixedRouteWeekdayAvgRevMiles: toNullableString(
+        body.fixedRouteWeekdayAvgRevMiles,
+      ),
+      fixedRouteSatAvgRiders: body.fixedRouteSatAvgRiders,
+      fixedRouteSatAvgRevHours: toNullableString(body.fixedRouteSatAvgRevHours),
+      fixedRouteSatAvgRevMiles: toNullableString(body.fixedRouteSatAvgRevMiles),
+      fixedRouteSunAvgRiders: body.fixedRouteSunAvgRiders,
+      fixedRouteSunAvgRevHours: toNullableString(body.fixedRouteSunAvgRevHours),
+      fixedRouteSunAvgRevMiles: toNullableString(body.fixedRouteSunAvgRevMiles),
+
+      demandResponseWeekdayAvgRiders: body.demandResponseWeekdayAvgRiders,
+      demandResponseWeekdayAvgRevHours: toNullableString(
+        body.demandResponseWeekdayAvgRevHours,
+      ),
+      demandResponseWeekdayAvgRevMiles: toNullableString(
+        body.demandResponseWeekdayAvgRevMiles,
+      ),
+      demandResponseSatAvgRiders: body.demandResponseSatAvgRiders,
+      demandResponseSatAvgRevHours: toNullableString(
+        body.demandResponseSatAvgRevHours,
+      ),
+      demandResponseSatAvgRevMiles: toNullableString(
+        body.demandResponseSatAvgRevMiles,
+      ),
+      demandResponseSunAvgRiders: body.demandResponseSunAvgRiders,
+      demandResponseSunAvgRevHours: toNullableString(
+        body.demandResponseSunAvgRevHours,
+      ),
+      demandResponseSunAvgRevMiles: toNullableString(
+        body.demandResponseSunAvgRevMiles,
+      ),
+    };
+
+    await db.insert(ntdOperationalMetrics).values(insertValues);
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("Error saving NTD operational metrics:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    if (!db) {
+      return NextResponse.json(
+        { error: "DATABASE_URL is not set" },
+        { status: 500 },
+      );
+    }
+
+    const monthlyReportIdParam = req.nextUrl.searchParams.get("monthlyReportId");
+    if (!monthlyReportIdParam) {
+      return NextResponse.json(
+        { error: "monthlyReportId query parameter is required" },
+        { status: 400 },
+      );
+    }
+
+    const monthlyReportId = Number(monthlyReportIdParam);
+    if (!Number.isFinite(monthlyReportId)) {
+      return NextResponse.json(
+        { error: "monthlyReportId must be a number" },
+        { status: 400 },
+      );
+    }
+
+    const rows = await db
+      .select()
+      .from(ntdOperationalMetrics)
+      .where(eq(ntdOperationalMetrics.monthlyReportId, monthlyReportId))
+      .limit(1);
+
+    return NextResponse.json(rows.length === 0 ? null : rows[0]);
+  } catch (error) {
+    console.error("Error loading NTD operational metrics:", error);
+    return NextResponse.json(
+      { error: "Failed to load metrics" },
+      { status: 500 },
+    );
+  }
+}
+

--- a/src/app/departments/hr/page.tsx
+++ b/src/app/departments/hr/page.tsx
@@ -16,7 +16,6 @@ type HrMetricRow = {
   otpSaturday: string | number | null;
   otpSunday: string | number | null;
   otpSystem: string | number | null;
-  peakVehicles: number | null;
   driverHours: string | number | null;
   overtimeHours: string | number | null;
   absenteeism: string | number | null;
@@ -52,7 +51,6 @@ export default function HRPage(): JSX.Element {
   const [otpSunday, setOtpSunday] = useState("");
   const [otpSystem, setOtpSystem] = useState("");
 
-  const [peakVehicles, setPeakVehicles] = useState("");
   const [driverHours, setDriverHours] = useState("");
   const [overtimeHours, setOvertimeHours] = useState("");
   const [absenteeism, setAbsenteeism] = useState("");
@@ -70,7 +68,6 @@ export default function HRPage(): JSX.Element {
   const isOtpSundayValid = isOtpPercent(otpSunday);
   const isOtpSystemValid = isOtpPercent(otpSystem);
 
-  const isPeakVehiclesValid = isNonNegative(peakVehicles);
   const isDriverHoursValid = isNonNegative(driverHours);
   const isOvertimeHoursValid = isNonNegative(overtimeHours);
   const isAbsenteeismValid = isNonNegative(absenteeism);
@@ -81,7 +78,6 @@ export default function HRPage(): JSX.Element {
     isOtpSaturdayValid &&
     isOtpSundayValid &&
     isOtpSystemValid &&
-    isPeakVehiclesValid &&
     isDriverHoursValid &&
     isOvertimeHoursValid &&
     isAbsenteeismValid;
@@ -116,7 +112,6 @@ export default function HRPage(): JSX.Element {
       otpSaturday: otpSaturday ? Number(otpSaturday) : null,
       otpSunday: otpSunday ? Number(otpSunday) : null,
       otpSystem: otpSystem ? Number(otpSystem) : null,
-      peakVehicles: peakVehicles ? Number(peakVehicles) : null,
       driverHours: driverHours ? Number(driverHours) : null,
       overtimeHours: overtimeHours ? Number(overtimeHours) : null,
       absenteeism: absenteeism ? Number(absenteeism) : null,
@@ -234,19 +229,6 @@ export default function HRPage(): JSX.Element {
               <Grid container spacing={3}>
                 <Grid size={{ xs: 12, md: 3 }}>
                   <TextField
-                    label="Peak Vehicles"
-                    type="number"
-                    value={peakVehicles}
-                    onChange={(e) => handleNumericChange(e.target.value, setPeakVehicles)}
-                    error={!isPeakVehiclesValid}
-                    helperText={isPeakVehiclesValid ? "" : "Must be a non-negative number."}
-                    inputProps={{ min: 0 }}
-                    fullWidth
-                  />
-                </Grid>
-
-                <Grid size={{ xs: 12, md: 3 }}>
-                  <TextField
                     label="Driver Hours"
                     type="number"
                     value={driverHours}
@@ -333,8 +315,7 @@ export default function HRPage(): JSX.Element {
               <Box component="ul" sx={{ pl: 3 }}>
                 {savedMetrics.map((metric) => (
                   <li key={metric.id}>
-                    {metric.reportingMonth} — OTP System: {metric.otpSystem ?? "N/A"}, Peak
-                    Vehicles: {metric.peakVehicles ?? "N/A"}
+                    {metric.reportingMonth} — OTP System: {metric.otpSystem ?? "N/A"}
                   </li>
                 ))}
               </Box>

--- a/src/app/departments/ntd-operational/page.tsx
+++ b/src/app/departments/ntd-operational/page.tsx
@@ -1,0 +1,706 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import type { JSX } from "react";
+
+import {
+  Box,
+  Button,
+  Divider,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import Grid from "@mui/material/Grid";
+import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import type { Dayjs } from "dayjs";
+
+type NtdOperationalMetricsRow = {
+  id: number;
+  monthlyReportId: number;
+
+  maxMotorBusesInService: number | null;
+  maxLiftVehiclesInService: number | null;
+
+  fixedRouteWeekdayAvgRiders: number | null;
+  fixedRouteWeekdayAvgRevHours: string | number | null;
+  fixedRouteWeekdayAvgRevMiles: string | number | null;
+  fixedRouteSatAvgRiders: number | null;
+  fixedRouteSatAvgRevHours: string | number | null;
+  fixedRouteSatAvgRevMiles: string | number | null;
+  fixedRouteSunAvgRiders: number | null;
+  fixedRouteSunAvgRevHours: string | number | null;
+  fixedRouteSunAvgRevMiles: string | number | null;
+
+  demandResponseWeekdayAvgRiders: number | null;
+  demandResponseWeekdayAvgRevHours: string | number | null;
+  demandResponseWeekdayAvgRevMiles: string | number | null;
+  demandResponseSatAvgRiders: number | null;
+  demandResponseSatAvgRevHours: string | number | null;
+  demandResponseSatAvgRevMiles: string | number | null;
+  demandResponseSunAvgRiders: number | null;
+  demandResponseSunAvgRevHours: string | number | null;
+  demandResponseSunAvgRevMiles: string | number | null;
+};
+
+const handleNumericChange = (
+  value: string,
+  setter: (value: string) => void,
+): void => {
+  if (value === "" || /^\d*\.?\d*$/.test(value)) {
+    setter(value);
+  }
+};
+
+function asNullableNumber(value: string): number | null {
+  if (value === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export default function NtdOperationalPage(): JSX.Element {
+  const [reportingMonth, setReportingMonth] = useState<Dayjs | null>(null);
+
+  const monthlyReportId = useMemo(() => {
+    return reportingMonth
+      ? reportingMonth.year() * 100 + (reportingMonth.month() + 1)
+      : null;
+  }, [reportingMonth]);
+
+  const [maxMotorBusesInService, setMaxMotorBusesInService] = useState("");
+  const [maxLiftVehiclesInService, setMaxLiftVehiclesInService] = useState("");
+
+  const [fixedRouteWeekdayAvgRiders, setFixedRouteWeekdayAvgRiders] =
+    useState("");
+  const [fixedRouteWeekdayAvgRevHours, setFixedRouteWeekdayAvgRevHours] =
+    useState("");
+  const [fixedRouteWeekdayAvgRevMiles, setFixedRouteWeekdayAvgRevMiles] =
+    useState("");
+  const [fixedRouteSatAvgRiders, setFixedRouteSatAvgRiders] = useState("");
+  const [fixedRouteSatAvgRevHours, setFixedRouteSatAvgRevHours] = useState("");
+  const [fixedRouteSatAvgRevMiles, setFixedRouteSatAvgRevMiles] = useState("");
+  const [fixedRouteSunAvgRiders, setFixedRouteSunAvgRiders] = useState("");
+  const [fixedRouteSunAvgRevHours, setFixedRouteSunAvgRevHours] = useState("");
+  const [fixedRouteSunAvgRevMiles, setFixedRouteSunAvgRevMiles] = useState("");
+
+  const [demandResponseWeekdayAvgRiders, setDemandResponseWeekdayAvgRiders] =
+    useState("");
+  const [demandResponseWeekdayAvgRevHours, setDemandResponseWeekdayAvgRevHours] =
+    useState("");
+  const [demandResponseWeekdayAvgRevMiles, setDemandResponseWeekdayAvgRevMiles] =
+    useState("");
+  const [demandResponseSatAvgRiders, setDemandResponseSatAvgRiders] =
+    useState("");
+  const [demandResponseSatAvgRevHours, setDemandResponseSatAvgRevHours] =
+    useState("");
+  const [demandResponseSatAvgRevMiles, setDemandResponseSatAvgRevMiles] =
+    useState("");
+  const [demandResponseSunAvgRiders, setDemandResponseSunAvgRiders] =
+    useState("");
+  const [demandResponseSunAvgRevHours, setDemandResponseSunAvgRevHours] =
+    useState("");
+  const [demandResponseSunAvgRevMiles, setDemandResponseSunAvgRevMiles] =
+    useState("");
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitSuccess, setSubmitSuccess] = useState(false);
+
+  async function loadExisting() {
+    if (!monthlyReportId) return;
+    setIsLoading(true);
+    setSubmitError(null);
+    setSubmitSuccess(false);
+
+    try {
+      const res = await fetch(
+        `/api/ntd-operational?monthlyReportId=${monthlyReportId}`,
+      );
+
+      if (!res.ok) {
+        const text = await res.text();
+        setSubmitError(text);
+        return;
+      }
+
+      const data = (await res.json()) as NtdOperationalMetricsRow | null;
+      if (!data) {
+        // Clear fields if nothing exists for that month
+        setMaxMotorBusesInService("");
+        setMaxLiftVehiclesInService("");
+        setFixedRouteWeekdayAvgRiders("");
+        setFixedRouteWeekdayAvgRevHours("");
+        setFixedRouteWeekdayAvgRevMiles("");
+        setFixedRouteSatAvgRiders("");
+        setFixedRouteSatAvgRevHours("");
+        setFixedRouteSatAvgRevMiles("");
+        setFixedRouteSunAvgRiders("");
+        setFixedRouteSunAvgRevHours("");
+        setFixedRouteSunAvgRevMiles("");
+        setDemandResponseWeekdayAvgRiders("");
+        setDemandResponseWeekdayAvgRevHours("");
+        setDemandResponseWeekdayAvgRevMiles("");
+        setDemandResponseSatAvgRiders("");
+        setDemandResponseSatAvgRevHours("");
+        setDemandResponseSatAvgRevMiles("");
+        setDemandResponseSunAvgRiders("");
+        setDemandResponseSunAvgRevHours("");
+        setDemandResponseSunAvgRevMiles("");
+        return;
+      }
+
+      setMaxMotorBusesInService(
+        data.maxMotorBusesInService === null
+          ? ""
+          : String(data.maxMotorBusesInService),
+      );
+      setMaxLiftVehiclesInService(
+        data.maxLiftVehiclesInService === null
+          ? ""
+          : String(data.maxLiftVehiclesInService),
+      );
+
+      setFixedRouteWeekdayAvgRiders(
+        data.fixedRouteWeekdayAvgRiders === null
+          ? ""
+          : String(data.fixedRouteWeekdayAvgRiders),
+      );
+      setFixedRouteWeekdayAvgRevHours(
+        data.fixedRouteWeekdayAvgRevHours === null
+          ? ""
+          : String(data.fixedRouteWeekdayAvgRevHours),
+      );
+      setFixedRouteWeekdayAvgRevMiles(
+        data.fixedRouteWeekdayAvgRevMiles === null
+          ? ""
+          : String(data.fixedRouteWeekdayAvgRevMiles),
+      );
+      setFixedRouteSatAvgRiders(
+        data.fixedRouteSatAvgRiders === null
+          ? ""
+          : String(data.fixedRouteSatAvgRiders),
+      );
+      setFixedRouteSatAvgRevHours(
+        data.fixedRouteSatAvgRevHours === null
+          ? ""
+          : String(data.fixedRouteSatAvgRevHours),
+      );
+      setFixedRouteSatAvgRevMiles(
+        data.fixedRouteSatAvgRevMiles === null
+          ? ""
+          : String(data.fixedRouteSatAvgRevMiles),
+      );
+      setFixedRouteSunAvgRiders(
+        data.fixedRouteSunAvgRiders === null
+          ? ""
+          : String(data.fixedRouteSunAvgRiders),
+      );
+      setFixedRouteSunAvgRevHours(
+        data.fixedRouteSunAvgRevHours === null
+          ? ""
+          : String(data.fixedRouteSunAvgRevHours),
+      );
+      setFixedRouteSunAvgRevMiles(
+        data.fixedRouteSunAvgRevMiles === null
+          ? ""
+          : String(data.fixedRouteSunAvgRevMiles),
+      );
+
+      setDemandResponseWeekdayAvgRiders(
+        data.demandResponseWeekdayAvgRiders === null
+          ? ""
+          : String(data.demandResponseWeekdayAvgRiders),
+      );
+      setDemandResponseWeekdayAvgRevHours(
+        data.demandResponseWeekdayAvgRevHours === null
+          ? ""
+          : String(data.demandResponseWeekdayAvgRevHours),
+      );
+      setDemandResponseWeekdayAvgRevMiles(
+        data.demandResponseWeekdayAvgRevMiles === null
+          ? ""
+          : String(data.demandResponseWeekdayAvgRevMiles),
+      );
+      setDemandResponseSatAvgRiders(
+        data.demandResponseSatAvgRiders === null
+          ? ""
+          : String(data.demandResponseSatAvgRiders),
+      );
+      setDemandResponseSatAvgRevHours(
+        data.demandResponseSatAvgRevHours === null
+          ? ""
+          : String(data.demandResponseSatAvgRevHours),
+      );
+      setDemandResponseSatAvgRevMiles(
+        data.demandResponseSatAvgRevMiles === null
+          ? ""
+          : String(data.demandResponseSatAvgRevMiles),
+      );
+      setDemandResponseSunAvgRiders(
+        data.demandResponseSunAvgRiders === null
+          ? ""
+          : String(data.demandResponseSunAvgRiders),
+      );
+      setDemandResponseSunAvgRevHours(
+        data.demandResponseSunAvgRevHours === null
+          ? ""
+          : String(data.demandResponseSunAvgRevHours),
+      );
+      setDemandResponseSunAvgRevMiles(
+        data.demandResponseSunAvgRevMiles === null
+          ? ""
+          : String(data.demandResponseSunAvgRevMiles),
+      );
+    } catch (err) {
+      console.error("[NTD Ops] failed to load metrics", err);
+      setSubmitError("Unexpected error while loading.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadExisting();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [monthlyReportId]);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!monthlyReportId) return;
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+    setSubmitSuccess(false);
+
+    const payload = {
+      monthlyReportId,
+
+      maxMotorBusesInService: asNullableNumber(maxMotorBusesInService),
+      maxLiftVehiclesInService: asNullableNumber(maxLiftVehiclesInService),
+
+      fixedRouteWeekdayAvgRiders: asNullableNumber(fixedRouteWeekdayAvgRiders),
+      fixedRouteWeekdayAvgRevHours: asNullableNumber(
+        fixedRouteWeekdayAvgRevHours,
+      ),
+      fixedRouteWeekdayAvgRevMiles: asNullableNumber(
+        fixedRouteWeekdayAvgRevMiles,
+      ),
+      fixedRouteSatAvgRiders: asNullableNumber(fixedRouteSatAvgRiders),
+      fixedRouteSatAvgRevHours: asNullableNumber(fixedRouteSatAvgRevHours),
+      fixedRouteSatAvgRevMiles: asNullableNumber(fixedRouteSatAvgRevMiles),
+      fixedRouteSunAvgRiders: asNullableNumber(fixedRouteSunAvgRiders),
+      fixedRouteSunAvgRevHours: asNullableNumber(fixedRouteSunAvgRevHours),
+      fixedRouteSunAvgRevMiles: asNullableNumber(fixedRouteSunAvgRevMiles),
+
+      demandResponseWeekdayAvgRiders: asNullableNumber(
+        demandResponseWeekdayAvgRiders,
+      ),
+      demandResponseWeekdayAvgRevHours: asNullableNumber(
+        demandResponseWeekdayAvgRevHours,
+      ),
+      demandResponseWeekdayAvgRevMiles: asNullableNumber(
+        demandResponseWeekdayAvgRevMiles,
+      ),
+      demandResponseSatAvgRiders: asNullableNumber(demandResponseSatAvgRiders),
+      demandResponseSatAvgRevHours: asNullableNumber(
+        demandResponseSatAvgRevHours,
+      ),
+      demandResponseSatAvgRevMiles: asNullableNumber(
+        demandResponseSatAvgRevMiles,
+      ),
+      demandResponseSunAvgRiders: asNullableNumber(demandResponseSunAvgRiders),
+      demandResponseSunAvgRevHours: asNullableNumber(
+        demandResponseSunAvgRevHours,
+      ),
+      demandResponseSunAvgRevMiles: asNullableNumber(
+        demandResponseSunAvgRevMiles,
+      ),
+    };
+
+    try {
+      const res = await fetch("/api/ntd-operational", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const text = await res.text();
+        setSubmitError(text);
+        return;
+      }
+
+      setSubmitSuccess(true);
+      await loadExisting();
+    } catch (err) {
+      console.error("[NTD Ops] failed to save metrics", err);
+      setSubmitError("Unexpected error while saving.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <main>
+      <LocalizationProvider dateAdapter={AdapterDayjs}>
+        <Box sx={{ p: 4 }}>
+          <Typography variant="h4" gutterBottom>
+            NTD Operational Metrics
+          </Typography>
+
+          <Typography variant="body1" sx={{ mb: 3 }}>
+            Enter monthly NTD-facing operational summary values (peak vehicles and
+            averages).
+          </Typography>
+
+          <Box component="form" onSubmit={handleSubmit}>
+            <Stack spacing={3}>
+              <Grid container spacing={3}>
+                <Grid size={{ xs: 12, md: 4 }}>
+                  <DatePicker
+                    label="Reporting Month"
+                    views={["year", "month"]}
+                    value={reportingMonth}
+                    onChange={(value) => setReportingMonth(value as Dayjs | null)}
+                    slotProps={{
+                      textField: { fullWidth: true, required: true },
+                    }}
+                  />
+                </Grid>
+              </Grid>
+
+              <Divider />
+
+              <Typography variant="h6">Peak vehicles (in service)</Typography>
+              <Grid container spacing={3}>
+                <Grid size={{ xs: 12, md: 3 }}>
+                  <TextField
+                    label="Max Motor Buses"
+                    value={maxMotorBusesInService}
+                    onChange={(e) =>
+                      handleNumericChange(e.target.value, setMaxMotorBusesInService)
+                    }
+                    inputProps={{ inputMode: "numeric" }}
+                    fullWidth
+                  />
+                </Grid>
+                <Grid size={{ xs: 12, md: 3 }}>
+                  <TextField
+                    label="Max Lift Vehicles"
+                    value={maxLiftVehiclesInService}
+                    onChange={(e) =>
+                      handleNumericChange(e.target.value, setMaxLiftVehiclesInService)
+                    }
+                    inputProps={{ inputMode: "numeric" }}
+                    fullWidth
+                  />
+                </Grid>
+              </Grid>
+
+              <Divider />
+
+              <Typography variant="h6">Fixed Route — daily averages</Typography>
+              <Typography variant="subtitle2">Weekday</Typography>
+              <Grid container spacing={3}>
+                <Grid size={{ xs: 12, md: 3 }}>
+                  <TextField
+                    label="Avg Riders"
+                    value={fixedRouteWeekdayAvgRiders}
+                    onChange={(e) =>
+                      handleNumericChange(
+                        e.target.value,
+                        setFixedRouteWeekdayAvgRiders,
+                      )
+                    }
+                    inputProps={{ inputMode: "numeric" }}
+                    fullWidth
+                  />
+                </Grid>
+                <Grid size={{ xs: 12, md: 3 }}>
+                  <TextField
+                    label="Avg Rev Hours"
+                    value={fixedRouteWeekdayAvgRevHours}
+                    onChange={(e) =>
+                      handleNumericChange(
+                        e.target.value,
+                        setFixedRouteWeekdayAvgRevHours,
+                      )
+                    }
+                    inputProps={{ inputMode: "decimal" }}
+                    fullWidth
+                  />
+                </Grid>
+                <Grid size={{ xs: 12, md: 3 }}>
+                  <TextField
+                    label="Avg Rev Miles"
+                    value={fixedRouteWeekdayAvgRevMiles}
+                    onChange={(e) =>
+                      handleNumericChange(
+                        e.target.value,
+                        setFixedRouteWeekdayAvgRevMiles,
+                      )
+                    }
+                    inputProps={{ inputMode: "decimal" }}
+                    fullWidth
+                  />
+                </Grid>
+              </Grid>
+
+              <Typography variant="subtitle2">Saturday</Typography>
+              <Grid container spacing={3}>
+                <Grid size={{ xs: 12, md: 3 }}>
+                  <TextField
+                    label="Avg Riders"
+                    value={fixedRouteSatAvgRiders}
+                    onChange={(e) =>
+                      handleNumericChange(e.target.value, setFixedRouteSatAvgRiders)
+                    }
+                    inputProps={{ inputMode: "numeric" }}
+                    fullWidth
+                  />
+                </Grid>
+                <Grid size={{ xs: 12, md: 3 }}>
+                  <TextField
+                    label="Avg Rev Hours"
+                    value={fixedRouteSatAvgRevHours}
+                    onChange={(e) =>
+                      handleNumericChange(
+                        e.target.value,
+                        setFixedRouteSatAvgRevHours,
+                      )
+                    }
+                    inputProps={{ inputMode: "decimal" }}
+                    fullWidth
+                  />
+                </Grid>
+                <Grid size={{ xs: 12, md: 3 }}>
+                  <TextField
+                    label="Avg Rev Miles"
+                    value={fixedRouteSatAvgRevMiles}
+                    onChange={(e) =>
+                      handleNumericChange(
+                        e.target.value,
+                        setFixedRouteSatAvgRevMiles,
+                      )
+                    }
+                    inputProps={{ inputMode: "decimal" }}
+                    fullWidth
+                  />
+                </Grid>
+              </Grid>
+
+              <Typography variant="subtitle2">Sunday</Typography>
+              <Grid container spacing={3}>
+                <Grid size={{ xs: 12, md: 3 }}>
+                  <TextField
+                    label="Avg Riders"
+                    value={fixedRouteSunAvgRiders}
+                    onChange={(e) =>
+                      handleNumericChange(e.target.value, setFixedRouteSunAvgRiders)
+                    }
+                    inputProps={{ inputMode: "numeric" }}
+                    fullWidth
+                  />
+                </Grid>
+                <Grid size={{ xs: 12, md: 3 }}>
+                  <TextField
+                    label="Avg Rev Hours"
+                    value={fixedRouteSunAvgRevHours}
+                    onChange={(e) =>
+                      handleNumericChange(
+                        e.target.value,
+                        setFixedRouteSunAvgRevHours,
+                      )
+                    }
+                    inputProps={{ inputMode: "decimal" }}
+                    fullWidth
+                  />
+                </Grid>
+                <Grid size={{ xs: 12, md: 3 }}>
+                  <TextField
+                    label="Avg Rev Miles"
+                    value={fixedRouteSunAvgRevMiles}
+                    onChange={(e) =>
+                      handleNumericChange(
+                        e.target.value,
+                        setFixedRouteSunAvgRevMiles,
+                      )
+                    }
+                    inputProps={{ inputMode: "decimal" }}
+                    fullWidth
+                  />
+                </Grid>
+              </Grid>
+
+              <Divider />
+
+              <Typography variant="h6">Demand Response — daily averages</Typography>
+              <Typography variant="subtitle2">Weekday</Typography>
+              <Grid container spacing={3}>
+                <Grid size={{ xs: 12, md: 3 }}>
+                  <TextField
+                    label="Avg Riders"
+                    value={demandResponseWeekdayAvgRiders}
+                    onChange={(e) =>
+                      handleNumericChange(
+                        e.target.value,
+                        setDemandResponseWeekdayAvgRiders,
+                      )
+                    }
+                    inputProps={{ inputMode: "numeric" }}
+                    fullWidth
+                  />
+                </Grid>
+                <Grid size={{ xs: 12, md: 3 }}>
+                  <TextField
+                    label="Avg Rev Hours"
+                    value={demandResponseWeekdayAvgRevHours}
+                    onChange={(e) =>
+                      handleNumericChange(
+                        e.target.value,
+                        setDemandResponseWeekdayAvgRevHours,
+                      )
+                    }
+                    inputProps={{ inputMode: "decimal" }}
+                    fullWidth
+                  />
+                </Grid>
+                <Grid size={{ xs: 12, md: 3 }}>
+                  <TextField
+                    label="Avg Rev Miles"
+                    value={demandResponseWeekdayAvgRevMiles}
+                    onChange={(e) =>
+                      handleNumericChange(
+                        e.target.value,
+                        setDemandResponseWeekdayAvgRevMiles,
+                      )
+                    }
+                    inputProps={{ inputMode: "decimal" }}
+                    fullWidth
+                  />
+                </Grid>
+              </Grid>
+
+              <Typography variant="subtitle2">Saturday</Typography>
+              <Grid container spacing={3}>
+                <Grid size={{ xs: 12, md: 3 }}>
+                  <TextField
+                    label="Avg Riders"
+                    value={demandResponseSatAvgRiders}
+                    onChange={(e) =>
+                      handleNumericChange(
+                        e.target.value,
+                        setDemandResponseSatAvgRiders,
+                      )
+                    }
+                    inputProps={{ inputMode: "numeric" }}
+                    fullWidth
+                  />
+                </Grid>
+                <Grid size={{ xs: 12, md: 3 }}>
+                  <TextField
+                    label="Avg Rev Hours"
+                    value={demandResponseSatAvgRevHours}
+                    onChange={(e) =>
+                      handleNumericChange(
+                        e.target.value,
+                        setDemandResponseSatAvgRevHours,
+                      )
+                    }
+                    inputProps={{ inputMode: "decimal" }}
+                    fullWidth
+                  />
+                </Grid>
+                <Grid size={{ xs: 12, md: 3 }}>
+                  <TextField
+                    label="Avg Rev Miles"
+                    value={demandResponseSatAvgRevMiles}
+                    onChange={(e) =>
+                      handleNumericChange(
+                        e.target.value,
+                        setDemandResponseSatAvgRevMiles,
+                      )
+                    }
+                    inputProps={{ inputMode: "decimal" }}
+                    fullWidth
+                  />
+                </Grid>
+              </Grid>
+
+              <Typography variant="subtitle2">Sunday</Typography>
+              <Grid container spacing={3}>
+                <Grid size={{ xs: 12, md: 3 }}>
+                  <TextField
+                    label="Avg Riders"
+                    value={demandResponseSunAvgRiders}
+                    onChange={(e) =>
+                      handleNumericChange(
+                        e.target.value,
+                        setDemandResponseSunAvgRiders,
+                      )
+                    }
+                    inputProps={{ inputMode: "numeric" }}
+                    fullWidth
+                  />
+                </Grid>
+                <Grid size={{ xs: 12, md: 3 }}>
+                  <TextField
+                    label="Avg Rev Hours"
+                    value={demandResponseSunAvgRevHours}
+                    onChange={(e) =>
+                      handleNumericChange(
+                        e.target.value,
+                        setDemandResponseSunAvgRevHours,
+                      )
+                    }
+                    inputProps={{ inputMode: "decimal" }}
+                    fullWidth
+                  />
+                </Grid>
+                <Grid size={{ xs: 12, md: 3 }}>
+                  <TextField
+                    label="Avg Rev Miles"
+                    value={demandResponseSunAvgRevMiles}
+                    onChange={(e) =>
+                      handleNumericChange(
+                        e.target.value,
+                        setDemandResponseSunAvgRevMiles,
+                      )
+                    }
+                    inputProps={{ inputMode: "decimal" }}
+                    fullWidth
+                  />
+                </Grid>
+              </Grid>
+
+              <Box>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  disabled={!monthlyReportId || isSubmitting || isLoading}
+                >
+                  {isSubmitting ? "Saving..." : "Save"}
+                </Button>
+
+                {submitError && (
+                  <Typography color="error" variant="body2" sx={{ mt: 1 }}>
+                    {submitError}
+                  </Typography>
+                )}
+
+                {submitSuccess && (
+                  <Typography color="success.main" variant="body2" sx={{ mt: 1 }}>
+                    Saved successfully.
+                  </Typography>
+                )}
+              </Box>
+            </Stack>
+          </Box>
+        </Box>
+      </LocalizationProvider>
+    </main>
+  );
+}
+

--- a/src/components/app-navbar.tsx
+++ b/src/components/app-navbar.tsx
@@ -16,6 +16,7 @@ const navLinks = [
   { label: "Maintenance", href: "/departments/maintenance" },
   { label: "Safety", href: "/departments/safety" },
   { label: "HR/Operations", href: "/departments/hr" },
+  { label: "NTD Ops", href: "/departments/ntd-operational" },
 ];
 
 export default function AppNavbar(): ReactElement {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -3,11 +3,13 @@ import { neon } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-http";
 import * as schema from "./schema";
 
-const sql = neon(process.env.DATABASE_URL!);
+const databaseUrl = process.env.DATABASE_URL;
 
-const db = drizzle({
-  client: sql,
-  schema,
-});
+const db = databaseUrl
+  ? drizzle({
+      client: neon(databaseUrl),
+      schema,
+    })
+  : null;
 
 export default db;

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -89,6 +89,18 @@ import {
   });
 
   /* ======================
+     MONTHLY DEPARTMENT REPORT TABLE
+     ====================== */
+  export const monthlyDepartmentReport = pgTable("monthly_department_report", {
+    // Matches existing UI convention: yyyymm (e.g. 202604)
+    id: integer("id").primaryKey(),
+    reportingMonth: date("reporting_month").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  });
+
+  /* ======================
      HR METRICS TABLE
      ====================== */
   export const hrMetrics = pgTable("hr_metrics", {
@@ -111,6 +123,46 @@ import {
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()
       .notNull(),
+  });
+
+  /* ======================
+     NTD OPERATIONAL METRICS TABLE
+     ====================== */
+  export const ntdOperationalMetrics = pgTable("ntd_operational_metrics", {
+    id: serial("id").primaryKey(),
+
+    monthlyReportId: integer("monthly_report_id")
+      .notNull()
+      .references(() => monthlyDepartmentReport.id, { onDelete: "cascade" }),
+
+    maxMotorBusesInService: integer("max_motor_buses_in_service"),
+    maxLiftVehiclesInService: integer("max_lift_vehicles_in_service"),
+
+    fixedRouteWeekdayAvgRiders: integer("fixed_route_weekday_avg_riders"),
+    fixedRouteWeekdayAvgRevHours: numeric("fixed_route_weekday_avg_rev_hours"),
+    fixedRouteWeekdayAvgRevMiles: numeric("fixed_route_weekday_avg_rev_miles"),
+    fixedRouteSatAvgRiders: integer("fixed_route_sat_avg_riders"),
+    fixedRouteSatAvgRevHours: numeric("fixed_route_sat_avg_rev_hours"),
+    fixedRouteSatAvgRevMiles: numeric("fixed_route_sat_avg_rev_miles"),
+    fixedRouteSunAvgRiders: integer("fixed_route_sun_avg_riders"),
+    fixedRouteSunAvgRevHours: numeric("fixed_route_sun_avg_rev_hours"),
+    fixedRouteSunAvgRevMiles: numeric("fixed_route_sun_avg_rev_miles"),
+
+    demandResponseWeekdayAvgRiders: integer(
+      "demand_response_weekday_avg_riders",
+    ),
+    demandResponseWeekdayAvgRevHours: numeric(
+      "demand_response_weekday_avg_rev_hours",
+    ),
+    demandResponseWeekdayAvgRevMiles: numeric(
+      "demand_response_weekday_avg_rev_miles",
+    ),
+    demandResponseSatAvgRiders: integer("demand_response_sat_avg_riders"),
+    demandResponseSatAvgRevHours: numeric("demand_response_sat_avg_rev_hours"),
+    demandResponseSatAvgRevMiles: numeric("demand_response_sat_avg_rev_miles"),
+    demandResponseSunAvgRiders: integer("demand_response_sun_avg_riders"),
+    demandResponseSunAvgRevHours: numeric("demand_response_sun_avg_rev_hours"),
+    demandResponseSunAvgRevMiles: numeric("demand_response_sun_avg_rev_miles"),
   });
 
   /* ======================


### PR DESCRIPTION
Add monthly_department_report and ntd_operational_metrics with Drizzle schema and migration. Expose GET/POST /api/ntd-operational keyed by monthlyReportId (yyyymm). Add NTD Ops department page and navbar link.

Remove peak vehicles from HR metrics API/UI; store peak motor/lift counts on NTD operational metrics instead.

Harden DB init when DATABASE_URL is missing; optional Drizzle adapter for NextAuth. Load .env.local in drizzle.config for migrations.

Made-with: Cursor

# Description

## Relevant Issues

## How to Test

## Miscellaneous Notes
